### PR TITLE
feature(setting):ユーザー設定画面作成

### DIFF
--- a/components/SettingComponent.tsx
+++ b/components/SettingComponent.tsx
@@ -1,0 +1,20 @@
+import React from "react";
+
+type Props = {
+  title: string;
+  contents: string;
+};
+
+const SettingComponent = ({ title, contents }: Props) => (
+  <div className="py-8 border-b-2">
+    <h2 className="text-lg font-semibold">{title}</h2>
+    <p className="mt-6">{contents}</p>
+    {title === "退会" && (
+      <button className="mt-4 px-4 py-2 border rounded-md shadow text-sm text-black focus:* focus:outline-none">
+        退会する
+      </button>
+    )}
+  </div>
+);
+
+export default SettingComponent;

--- a/pages/setting.tsx
+++ b/pages/setting.tsx
@@ -1,0 +1,30 @@
+import Layout from "../components/Layout";
+import SettingComponent from "../components/SettingComponent";
+
+export default function Terms() {
+  const settingContents = [
+    {
+      title: "プロフィールの変更",
+      contents:
+        "このサイトではプロフィールの変更はできません。Googleのアカウント情報がそのまま反映されます。(ログイン時に反映されます。)",
+    },
+    {
+      title: "退会",
+      contents:
+        "退会すると作成されたライブラリは全て削除され、戻すことはできません。",
+    },
+  ];
+  return (
+    <Layout>
+      <div className="pt-24 container-sm mx-auto px-4">
+        <h1 className="text-2xl pb-4 font-bold border-b-2">ユーザー設定</h1>
+        {settingContents.map((settingContent) => (
+          <SettingComponent
+            title={settingContent.title}
+            contents={settingContent.contents}
+          />
+        ))}
+      </div>
+    </Layout>
+  );
+}


### PR DESCRIPTION
fix #17 
## 実装内容
- ユーザー設定画面（プロフィール変更、退会）
※このサイトではプロフィールの変更機能は実装しないです。
- 共通部分のコンポーネント化：SettingComponent.tsx

## 実装していないこと
- 退会処理

## イメージ
![image](https://user-images.githubusercontent.com/66728424/107136025-17536a00-6943-11eb-8c92-f2d78d412935.png)

ご確認お願いします。