### PR TITLE
fix(seach&heddaer):検索欄をヘッダーに配置

### DIFF
--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -1,46 +1,93 @@
-import React, { ReactNode } from 'react'
-import Link from 'next/link'
-import Head from 'next/head'
+import React, { ReactNode, useState } from "react";
+import Link from "next/link";
+import Head from "next/head";
 
 type Props = {
-  children?: ReactNode
-  title?: string
-}
+  children?: ReactNode;
+  title?: string;
+};
 
-const Layout = ({ children, title = 'This is the default title' }: Props) => (
-  <div>
-    <Head>
-      <title>{title}</title>
-      <meta charSet="utf-8" />
-      <meta name="viewport" content="initial-scale=1.0, width=device-width" />
-    </Head>
-    <header className="fixed top-0 -inset-x-0 bg-blue-600">
-      <div className="container-sm mx-auto px-2">
-        <div className="items-center flex justify-between p-4 border-b-1">
-          <a className="text-white text-base">
-          LOGO
+const Layout = ({ children, title = "This is the default title" }: Props) => {
+  const [searchBarVisible, setSearchBarVisible] = useState(false);
+  const onClickSearchBarVisible = () => {
+    setSearchBarVisible(!searchBarVisible);
+  };
+  return (
+    <div>
+      <Head>
+        <title>{title}</title>
+        <meta charSet="utf-8" />
+        <meta name="viewport" content="initial-scale=1.0, width=device-width" />
+      </Head>
+      <header className="fixed top-0 -inset-x-0 bg-blue-600 p-2 flex justify-between items-center md:space-x-2">
+        <a className="text-white text-base">LOGO</a>
+        <div className="items-center hidden w-full sm:flex">
+          <input
+            type="text"
+            className="ml-3 md:w-11/12 whitespace-nowrap px-2 py-2 border border-white rounded-l-md shadow-sm text-sm font-medium outline-none"
+            placeholder="本のタイトルを入力"
+          />
+          <a
+            href="#"
+            className="inline-flex items-center justify-center px-2 py-2 border border-white rounded-r-md shadow-sm text-sm font-medium text-white hover:bg-blue-500"
+          >
+            <img src="/images/search.svg" alt="" className="w-5 rounded-md" />
           </a>
-          <nav className="md:ml-auto flex flex-wrap items-center text-base justify-center">
-            <a href="#" className="ml-3 whitespace-nowrap inline-flex items-center justify-center px-2 py-2 border border-white rounded-md shadow-sm text-sm font-medium text-white hover:bg-blue-500">
-              本を検索する
-            </a>
-            <a href="#" className="ml-3 whitespace-nowrap inline-flex items-center justify-center px-2 py-2 border border-white rounded-md shadow-sm text-sm font-medium text-white hover:bg-blue-500">
-              ログイン
-            </a>
-          </nav>
         </div>
-      </div>
-    </header>
-    <main>{children}</main>
-    <footer className="pt-10 pb-8 bg-gray-50">
-      <div className="flex flex-wrap justify-center space-x-4">
-        <a href="#">利用規約</a>
-        <a href="#">プライバシーポリシー</a>
-        <a href="#">お問合せ</a>
-      </div>
-      <p className="text-center m-4">©️E-LOVE</p>
-    </footer>
-  </div>
-)
+        <div className="flex items-center">
+          <a
+            href="#"
+            className="inline-flex items-center justify-center px-2 py-2 border border-white rounded-md shadow-sm text-sm font-medium text-white hover:bg-blue-500 sm:hidden"
+            onClick={onClickSearchBarVisible}
+          >
+            <img src="/images/search.svg" alt="" className="w-5" />
+          </a>
+          <a
+            href="#"
+            className="ml-2 whitespace-nowrap inline-flex items-center justify-center px-2 py-2 border border-white rounded-md shadow-sm text-sm font-medium text-white hover:bg-blue-500"
+          >
+            ログイン
+          </a>
+        </div>
+      </header>
 
-export default Layout
+      {searchBarVisible && (
+        <div className="fixed top-0 -inset-x-0 bg-blue-600 p-2 flex justify-between items-center sm:hidden">
+          <div className="flex items-center w-full">
+            <a
+              href="#"
+              className="inline-flex items-center justify-center px-1 py-1 shadow-sm text-sm font-nomal text-white hover:bg-blue-500"
+              onClick={onClickSearchBarVisible}
+            >
+              <img src="/images/arrow-left.svg" alt="" className="w-5" />
+            </a>
+
+            <input
+              type="text"
+              className="ml-1 w-9/12 whitespace-nowrap px-2 py-2 border border-white rounded-l-md shadow-sm text-sm font-medium outline-none"
+              placeholder="本のタイトルを入力"
+            />
+            <a
+              href="#"
+              className="inline-flex items-center justify-center px-2 py-2 border border-white rounded-r-md shadow-sm text-sm font-medium text-white hover:bg-blue-500"
+            >
+              <img src="/images/search.svg" alt="" className="w-5 rounded-md" />
+            </a>
+          </div>
+        </div>
+      )}
+
+      <main>{children}</main>
+      <footer className="pt-10 pb-8 bg-gray-50">
+        <div className="flex flex-wrap justify-center space-x-4">
+          <a href="#">利用規約</a>
+          <a href="#">プライバシーポリシー</a>
+          <a href="#">お問合せ</a>
+        </div>
+        <p className="text-center m-4">©️E-LOVE</p>
+      </footer>
+    </div>
+  );
+};
+
+export default Layout;

--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -1,50 +1,51 @@
-import React, { ReactNode, useState } from "react";
-import Link from "next/link";
-import Head from "next/head";
+import React, { ReactNode, useState } from 'react';
+import Link from 'next/link';
+import Head from 'next/head';
 
 type Props = {
   children?: ReactNode;
   title?: string;
 };
 
-const Layout = ({ children, title = "This is the default title" }: Props) => {
+const Layout = ({ children, title = 'This is the default title' }: Props) => {
   const [searchBarVisible, setSearchBarVisible] = useState(false);
   const onClickSearchBarVisible = () => {
     setSearchBarVisible(!searchBarVisible);
   };
+
   return (
     <div>
       <Head>
         <title>{title}</title>
-        <meta charSet="utf-8" />
-        <meta name="viewport" content="initial-scale=1.0, width=device-width" />
+        <meta charSet='utf-8' />
+        <meta name='viewport' content='initial-scale=1.0, width=device-width' />
       </Head>
-      <header className="fixed top-0 -inset-x-0 bg-blue-600 p-2 flex justify-between items-center md:space-x-2">
-        <a className="text-white text-base">LOGO</a>
-        <div className="items-center hidden w-full sm:flex">
+      <header className='fixed top-0 -inset-x-0 bg-blue-600 p-2 flex justify-between items-center md:space-x-2'>
+        <a className='text-white text-base'>LOGO</a>
+        <div className='items-center hidden w-full sm:flex'>
           <input
-            type="text"
-            className="ml-3 md:w-11/12 whitespace-nowrap px-2 py-2 border border-white rounded-l-md shadow-sm text-sm font-medium outline-none"
-            placeholder="本のタイトルを入力"
+            type='text'
+            className='ml-3 md:w-11/12 whitespace-nowrap px-2 py-2 border border-white rounded-l-md shadow-sm text-sm font-medium outline-none'
+            placeholder='本のタイトルを入力'
           />
           <a
-            href="#"
-            className="inline-flex items-center justify-center px-2 py-2 border border-white rounded-r-md shadow-sm text-sm font-medium text-white hover:bg-blue-500"
+            href='#'
+            className='inline-flex items-center justify-center px-2 py-2 border border-white rounded-r-md shadow-sm text-sm font-medium text-white hover:bg-blue-500'
           >
-            <img src="/images/search.svg" alt="" className="w-5 rounded-md" />
+            <img src='/images/search.svg' alt='' className='w-5 rounded-md' />
           </a>
         </div>
-        <div className="flex items-center">
+        <div className='flex items-center'>
           <a
-            href="#"
-            className="inline-flex items-center justify-center px-2 py-2 border border-white rounded-md shadow-sm text-sm font-medium text-white hover:bg-blue-500 sm:hidden"
+            href='#'
+            className='inline-flex items-center justify-center px-2 py-2 border border-white rounded-md shadow-sm text-sm font-medium text-white hover:bg-blue-500 sm:hidden'
             onClick={onClickSearchBarVisible}
           >
-            <img src="/images/search.svg" alt="" className="w-5" />
+            <img src='/images/search.svg' alt='' className='w-5' />
           </a>
           <a
-            href="#"
-            className="ml-2 whitespace-nowrap inline-flex items-center justify-center px-2 py-2 border border-white rounded-md shadow-sm text-sm font-medium text-white hover:bg-blue-500"
+            href='#'
+            className='ml-2 whitespace-nowrap inline-flex items-center justify-center px-2 py-2 border border-white rounded-md shadow-sm text-sm font-medium text-white hover:bg-blue-500'
           >
             ログイン
           </a>
@@ -52,39 +53,39 @@ const Layout = ({ children, title = "This is the default title" }: Props) => {
       </header>
 
       {searchBarVisible && (
-        <div className="fixed top-0 -inset-x-0 bg-blue-600 p-2 flex justify-between items-center sm:hidden">
-          <div className="flex items-center w-full">
+        <div className='fixed top-0 -inset-x-0 bg-blue-600 p-2 flex justify-between items-center sm:hidden'>
+          <div className='flex items-center w-full'>
             <a
-              href="#"
-              className="inline-flex items-center justify-center px-1 py-1 shadow-sm text-sm font-nomal text-white hover:bg-blue-500"
+              href='#'
+              className='inline-flex items-center justify-center px-1 py-1 shadow-sm text-sm font-nomal text-white hover:bg-blue-500'
               onClick={onClickSearchBarVisible}
             >
-              <img src="/images/arrow-left.svg" alt="" className="w-5" />
+              <img src='/images/arrow-left.svg' alt='' className='w-5' />
             </a>
 
             <input
-              type="text"
-              className="ml-1 w-9/12 whitespace-nowrap px-2 py-2 border border-white rounded-l-md shadow-sm text-sm font-medium outline-none"
-              placeholder="本のタイトルを入力"
+              type='text'
+              className='ml-1 w-9/12 whitespace-nowrap px-2 py-2 border border-white rounded-l-md shadow-sm text-sm font-medium outline-none'
+              placeholder='本のタイトルを入力'
             />
             <a
-              href="#"
-              className="inline-flex items-center justify-center px-2 py-2 border border-white rounded-r-md shadow-sm text-sm font-medium text-white hover:bg-blue-500"
+              href='#'
+              className='inline-flex items-center justify-center px-2 py-2 border border-white rounded-r-md shadow-sm text-sm font-medium text-white hover:bg-blue-500'
             >
-              <img src="/images/search.svg" alt="" className="w-5 rounded-md" />
+              <img src='/images/search.svg' alt='' className='w-5 rounded-md' />
             </a>
           </div>
         </div>
       )}
 
       <main>{children}</main>
-      <footer className="pt-10 pb-8 bg-gray-50">
-        <div className="flex flex-wrap justify-center space-x-4">
-          <a href="#">利用規約</a>
-          <a href="#">プライバシーポリシー</a>
-          <a href="#">お問合せ</a>
+      <footer className='pt-10 pb-8 bg-gray-50'>
+        <div className='flex flex-wrap justify-center space-x-4'>
+          <a href='#'>利用規約</a>
+          <a href='#'>プライバシーポリシー</a>
+          <a href='#'>お問合せ</a>
         </div>
-        <p className="text-center m-4">©️E-LOVE</p>
+        <p className='text-center m-4'>©️E-LOVE</p>
       </footer>
     </div>
   );

--- a/pages/search.tsx
+++ b/pages/search.tsx
@@ -1,127 +1,127 @@
-import Layout from "../components/Layout";
+import Layout from '../components/Layout';
 
 export default function Search() {
   return (
     <Layout>
-      <div className="py-7 px-4">
-        <div className="pt-10">
+      <div className='py-7 px-4'>
+        <div className='pt-10'>
           <h1>検索結果</h1>
-          <div className="grid grid-cols-2 gap-4 bg-grey-light py-8 w-full @screen sm:grid-cols-4">
-            <div className="bg-white rounded w-1/8 shadow hover:shadow-md duration-4">
-              <div className="p-2 text-grey-darker text-justify flex flex-col">
+          <div className='grid grid-cols-2 gap-4 bg-grey-light py-8 w-full @screen sm:grid-cols-4'>
+            <div className='bg-white rounded w-1/8 shadow hover:shadow-md duration-4'>
+              <div className='p-2 text-grey-darker text-justify flex flex-col'>
                 <img
-                  src="https://picsum.photos/200/250"
-                  alt="Some image"
-                  className="w-32 flex self-center shadow-lg mb-4"
+                  src='https://picsum.photos/200/250'
+                  alt='Some image'
+                  className='w-32 flex self-center shadow-lg mb-4'
                 />
-                <p className="font-bold text-sm uppercase mb-2 text-blue-darker">
+                <p className='font-bold text-sm uppercase mb-2 text-blue-darker'>
                   本のタイトル
                 </p>
-                <div className="flex flex-col">
-                  <button className="bg-yellow-400 text-white font-bold p-2 text-xs shadow rounded">
+                <div className='flex flex-col'>
+                  <button className='bg-yellow-400 text-white font-bold p-2 text-xs shadow rounded'>
                     Amazon詳細
                   </button>
-                  <button className="bg-blue-400 text-white font-bold p-2 text-xs shadow rounded">
+                  <button className='bg-blue-400 text-white font-bold p-2 text-xs shadow rounded'>
                     ライブラリに登録
                   </button>
                 </div>
               </div>
             </div>
-            <div className="bg-white rounded w-1/8 shadow hover:shadow-md duration-4">
-              <div className="p-2 text-grey-darker text-justify flex flex-col">
+            <div className='bg-white rounded w-1/8 shadow hover:shadow-md duration-4'>
+              <div className='p-2 text-grey-darker text-justify flex flex-col'>
                 <img
-                  src="https://picsum.photos/200/250"
-                  alt="Some image"
-                  className="w-32 flex self-center shadow-lg mb-4"
+                  src='https://picsum.photos/200/250'
+                  alt='Some image'
+                  className='w-32 flex self-center shadow-lg mb-4'
                 />
-                <p className="font-bold text-sm uppercase mb-2 text-blue-darker">
+                <p className='font-bold text-sm uppercase mb-2 text-blue-darker'>
                   本のタイトル
                 </p>
-                <div className="flex flex-col">
-                  <button className="bg-yellow-400 text-white font-bold p-2 text-xs shadow rounded">
+                <div className='flex flex-col'>
+                  <button className='bg-yellow-400 text-white font-bold p-2 text-xs shadow rounded'>
                     Amazon詳細
                   </button>
-                  <button className="bg-blue-400 text-white font-bold p-2 text-xs shadow rounded">
+                  <button className='bg-blue-400 text-white font-bold p-2 text-xs shadow rounded'>
                     ライブラリに登録
                   </button>
                 </div>
               </div>
             </div>
-            <div className="bg-white rounded w-1/8 shadow hover:shadow-md duration-4">
-              <div className="p-2 text-grey-darker text-justify flex flex-col">
+            <div className='bg-white rounded w-1/8 shadow hover:shadow-md duration-4'>
+              <div className='p-2 text-grey-darker text-justify flex flex-col'>
                 <img
-                  src="https://picsum.photos/200/250"
-                  alt="Some image"
-                  className="w-32 flex self-center shadow-lg mb-4"
+                  src='https://picsum.photos/200/250'
+                  alt='Some image'
+                  className='w-32 flex self-center shadow-lg mb-4'
                 />
-                <p className="font-bold text-sm uppercase mb-2 text-blue-darker">
+                <p className='font-bold text-sm uppercase mb-2 text-blue-darker'>
                   本のタイトル
                 </p>
-                <div className="flex flex-col">
-                  <button className="bg-yellow-400 text-white font-bold p-2 text-xs shadow rounded">
+                <div className='flex flex-col'>
+                  <button className='bg-yellow-400 text-white font-bold p-2 text-xs shadow rounded'>
                     Amazon詳細
                   </button>
-                  <button className="bg-blue-400 text-white font-bold p-2 text-xs shadow rounded">
+                  <button className='bg-blue-400 text-white font-bold p-2 text-xs shadow rounded'>
                     ライブラリに登録
                   </button>
                 </div>
               </div>
             </div>
-            <div className="bg-white rounded w-1/8 shadow hover:shadow-md duration-4">
-              <div className="p-2 text-grey-darker text-justify flex flex-col">
+            <div className='bg-white rounded w-1/8 shadow hover:shadow-md duration-4'>
+              <div className='p-2 text-grey-darker text-justify flex flex-col'>
                 <img
-                  src="https://picsum.photos/200/250"
-                  alt="Some image"
-                  className="w-32 flex self-center shadow-lg mb-4"
+                  src='https://picsum.photos/200/250'
+                  alt='Some image'
+                  className='w-32 flex self-center shadow-lg mb-4'
                 />
-                <p className="font-bold text-sm uppercase mb-2 text-blue-darker">
+                <p className='font-bold text-sm uppercase mb-2 text-blue-darker'>
                   本のタイトル
                 </p>
-                <div className="flex flex-col">
-                  <button className="bg-yellow-400 text-white font-bold p-2 text-xs shadow rounded">
+                <div className='flex flex-col'>
+                  <button className='bg-yellow-400 text-white font-bold p-2 text-xs shadow rounded'>
                     Amazon詳細
                   </button>
-                  <button className="bg-blue-400 text-white font-bold p-2 text-xs shadow rounded">
+                  <button className='bg-blue-400 text-white font-bold p-2 text-xs shadow rounded'>
                     ライブラリに登録
                   </button>
                 </div>
               </div>
             </div>
-            <div className="bg-white rounded w-1/8 shadow hover:shadow-md duration-4">
-              <div className="p-2 text-grey-darker text-justify flex flex-col">
+            <div className='bg-white rounded w-1/8 shadow hover:shadow-md duration-4'>
+              <div className='p-2 text-grey-darker text-justify flex flex-col'>
                 <img
-                  src="https://picsum.photos/200/250"
-                  alt="Some image"
-                  className="w-32 flex self-center shadow-lg mb-4"
+                  src='https://picsum.photos/200/250'
+                  alt='Some image'
+                  className='w-32 flex self-center shadow-lg mb-4'
                 />
-                <p className="font-bold text-sm uppercase mb-2 text-blue-darker">
+                <p className='font-bold text-sm uppercase mb-2 text-blue-darker'>
                   本のタイトル
                 </p>
-                <div className="flex flex-col">
-                  <button className="bg-yellow-400 text-white font-bold p-2 text-xs shadow rounded">
+                <div className='flex flex-col'>
+                  <button className='bg-yellow-400 text-white font-bold p-2 text-xs shadow rounded'>
                     Amazon詳細
                   </button>
-                  <button className="bg-blue-400 text-white font-bold p-2 text-xs shadow rounded">
+                  <button className='bg-blue-400 text-white font-bold p-2 text-xs shadow rounded'>
                     ライブラリに登録
                   </button>
                 </div>
               </div>
             </div>
-            <div className="bg-white rounded w-1/8 shadow hover:shadow-md duration-4">
-              <div className="p-2 text-grey-darker text-justify flex flex-col">
+            <div className='bg-white rounded w-1/8 shadow hover:shadow-md duration-4'>
+              <div className='p-2 text-grey-darker text-justify flex flex-col'>
                 <img
-                  src="https://picsum.photos/200/250"
-                  alt="Some image"
-                  className="w-32 flex self-center shadow-lg mb-4"
+                  src='https://picsum.photos/200/250'
+                  alt='Some image'
+                  className='w-32 flex self-center shadow-lg mb-4'
                 />
-                <p className="font-bold text-sm uppercase mb-2 text-blue-darker">
+                <p className='font-bold text-sm uppercase mb-2 text-blue-darker'>
                   本のタイトル
                 </p>
-                <div className="flex flex-col">
-                  <button className="bg-yellow-400 text-white font-bold p-2 text-xs shadow rounded">
+                <div className='flex flex-col'>
+                  <button className='bg-yellow-400 text-white font-bold p-2 text-xs shadow rounded'>
                     Amazon詳細
                   </button>
-                  <button className="bg-blue-400 text-white font-bold p-2 text-xs shadow rounded">
+                  <button className='bg-blue-400 text-white font-bold p-2 text-xs shadow rounded'>
                     ライブラリに登録
                   </button>
                 </div>
@@ -129,124 +129,124 @@ export default function Search() {
             </div>
           </div>
         </div>
-        <div className="pt-8">
+        <div className='pt-8'>
           <p>あなたへのおすすめ</p>
-          <div className="grid grid-cols-2 gap-4 bg-grey-light py-8 w-full @screen sm:grid-cols-4">
-            <div className="bg-white rounded w-1/8 shadow hover:shadow-md duration-4">
-              <div className="p-2 text-grey-darker text-justify flex flex-col">
+          <div className='grid grid-cols-2 gap-4 bg-grey-light py-8 w-full @screen sm:grid-cols-4'>
+            <div className='bg-white rounded w-1/8 shadow hover:shadow-md duration-4'>
+              <div className='p-2 text-grey-darker text-justify flex flex-col'>
                 <img
-                  src="https://picsum.photos/200/250"
-                  alt="Some image"
-                  className="w-32 flex self-center shadow-lg mb-4"
+                  src='https://picsum.photos/200/250'
+                  alt='Some image'
+                  className='w-32 flex self-center shadow-lg mb-4'
                 />
-                <p className="font-bold text-sm uppercase mb-2 text-blue-darker">
+                <p className='font-bold text-sm uppercase mb-2 text-blue-darker'>
                   本のタイトル
                 </p>
-                <div className="flex flex-col">
-                  <button className="bg-yellow-400 text-white font-bold p-2 text-xs shadow rounded">
+                <div className='flex flex-col'>
+                  <button className='bg-yellow-400 text-white font-bold p-2 text-xs shadow rounded'>
                     Amazon詳細
                   </button>
-                  <button className="bg-blue-400 text-white font-bold p-2 text-xs shadow rounded">
+                  <button className='bg-blue-400 text-white font-bold p-2 text-xs shadow rounded'>
                     ライブラリに登録
                   </button>
                 </div>
               </div>
             </div>
-            <div className="bg-white rounded w-1/8 shadow hover:shadow-md duration-4">
-              <div className="p-2 text-grey-darker text-justify flex flex-col">
+            <div className='bg-white rounded w-1/8 shadow hover:shadow-md duration-4'>
+              <div className='p-2 text-grey-darker text-justify flex flex-col'>
                 <img
-                  src="https://picsum.photos/200/250"
-                  alt="Some image"
-                  className="w-32 flex self-center shadow-lg mb-4"
+                  src='https://picsum.photos/200/250'
+                  alt='Some image'
+                  className='w-32 flex self-center shadow-lg mb-4'
                 />
-                <p className="font-bold text-sm uppercase mb-2 text-blue-darker">
+                <p className='font-bold text-sm uppercase mb-2 text-blue-darker'>
                   本のタイトル
                 </p>
-                <div className="flex flex-col">
-                  <button className="bg-yellow-400 text-white font-bold p-2 text-xs shadow rounded">
+                <div className='flex flex-col'>
+                  <button className='bg-yellow-400 text-white font-bold p-2 text-xs shadow rounded'>
                     Amazon詳細
                   </button>
-                  <button className="bg-blue-400 text-white font-bold p-2 text-xs shadow rounded">
+                  <button className='bg-blue-400 text-white font-bold p-2 text-xs shadow rounded'>
                     ライブラリに登録
                   </button>
                 </div>
               </div>
             </div>
-            <div className="bg-white rounded w-1/8 shadow hover:shadow-md duration-4">
-              <div className="p-2 text-grey-darker text-justify flex flex-col">
+            <div className='bg-white rounded w-1/8 shadow hover:shadow-md duration-4'>
+              <div className='p-2 text-grey-darker text-justify flex flex-col'>
                 <img
-                  src="https://picsum.photos/200/250"
-                  alt="Some image"
-                  className="w-32 flex self-center shadow-lg mb-4"
+                  src='https://picsum.photos/200/250'
+                  alt='Some image'
+                  className='w-32 flex self-center shadow-lg mb-4'
                 />
-                <p className="font-bold text-sm uppercase mb-2 text-blue-darker">
+                <p className='font-bold text-sm uppercase mb-2 text-blue-darker'>
                   本のタイトル
                 </p>
-                <div className="flex flex-col">
-                  <button className="bg-yellow-400 text-white font-bold p-2 text-xs shadow rounded">
+                <div className='flex flex-col'>
+                  <button className='bg-yellow-400 text-white font-bold p-2 text-xs shadow rounded'>
                     Amazon詳細
                   </button>
-                  <button className="bg-blue-400 text-white font-bold p-2 text-xs shadow rounded">
+                  <button className='bg-blue-400 text-white font-bold p-2 text-xs shadow rounded'>
                     ライブラリに登録
                   </button>
                 </div>
               </div>
             </div>
-            <div className="bg-white rounded w-1/8 shadow hover:shadow-md duration-4">
-              <div className="p-2 text-grey-darker text-justify flex flex-col">
+            <div className='bg-white rounded w-1/8 shadow hover:shadow-md duration-4'>
+              <div className='p-2 text-grey-darker text-justify flex flex-col'>
                 <img
-                  src="https://picsum.photos/200/250"
-                  alt="Some image"
-                  className="w-32 flex self-center shadow-lg mb-4"
+                  src='https://picsum.photos/200/250'
+                  alt='Some image'
+                  className='w-32 flex self-center shadow-lg mb-4'
                 />
-                <p className="font-bold text-sm uppercase mb-2 text-blue-darker">
+                <p className='font-bold text-sm uppercase mb-2 text-blue-darker'>
                   本のタイトル
                 </p>
-                <div className="flex flex-col">
-                  <button className="bg-yellow-400 text-white font-bold p-2 text-xs shadow rounded">
+                <div className='flex flex-col'>
+                  <button className='bg-yellow-400 text-white font-bold p-2 text-xs shadow rounded'>
                     Amazon詳細
                   </button>
-                  <button className="bg-blue-400 text-white font-bold p-2 text-xs shadow rounded">
+                  <button className='bg-blue-400 text-white font-bold p-2 text-xs shadow rounded'>
                     ライブラリに登録
                   </button>
                 </div>
               </div>
             </div>
-            <div className="bg-white rounded w-1/8 shadow hover:shadow-md duration-4">
-              <div className="p-2 text-grey-darker text-justify flex flex-col">
+            <div className='bg-white rounded w-1/8 shadow hover:shadow-md duration-4'>
+              <div className='p-2 text-grey-darker text-justify flex flex-col'>
                 <img
-                  src="https://picsum.photos/200/250"
-                  alt="Some image"
-                  className="w-32 flex self-center shadow-lg mb-4"
+                  src='https://picsum.photos/200/250'
+                  alt='Some image'
+                  className='w-32 flex self-center shadow-lg mb-4'
                 />
-                <p className="font-bold text-sm uppercase mb-2 text-blue-darker">
+                <p className='font-bold text-sm uppercase mb-2 text-blue-darker'>
                   本のタイトル
                 </p>
-                <div className="flex flex-col">
-                  <button className="bg-yellow-400 text-white font-bold p-2 text-xs shadow rounded">
+                <div className='flex flex-col'>
+                  <button className='bg-yellow-400 text-white font-bold p-2 text-xs shadow rounded'>
                     Amazon詳細
                   </button>
-                  <button className="bg-blue-400 text-white font-bold p-2 text-xs shadow rounded">
+                  <button className='bg-blue-400 text-white font-bold p-2 text-xs shadow rounded'>
                     ライブラリに登録
                   </button>
                 </div>
               </div>
             </div>
-            <div className="bg-white rounded w-1/8 shadow hover:shadow-md duration-4">
-              <div className="p-2 text-grey-darker text-justify flex flex-col">
+            <div className='bg-white rounded w-1/8 shadow hover:shadow-md duration-4'>
+              <div className='p-2 text-grey-darker text-justify flex flex-col'>
                 <img
-                  src="https://picsum.photos/200/250"
-                  alt="Some image"
-                  className="w-32 flex self-center shadow-lg mb-4"
+                  src='https://picsum.photos/200/250'
+                  alt='Some image'
+                  className='w-32 flex self-center shadow-lg mb-4'
                 />
-                <p className="font-bold text-sm uppercase mb-2 text-blue-darker">
+                <p className='font-bold text-sm uppercase mb-2 text-blue-darker'>
                   本のタイトル
                 </p>
-                <div className="flex flex-col">
-                  <button className="bg-yellow-400 text-white font-bold p-2 text-xs shadow rounded">
+                <div className='flex flex-col'>
+                  <button className='bg-yellow-400 text-white font-bold p-2 text-xs shadow rounded'>
                     Amazon詳細
                   </button>
-                  <button className="bg-blue-400 text-white font-bold p-2 text-xs shadow rounded">
+                  <button className='bg-blue-400 text-white font-bold p-2 text-xs shadow rounded'>
                     ライブラリに登録
                   </button>
                 </div>

--- a/pages/search.tsx
+++ b/pages/search.tsx
@@ -4,19 +4,8 @@ export default function Search() {
   return (
     <Layout>
       <div className="py-7 px-4">
-        <form className="flex flex-grow w-full">
-          <input
-            type="text"
-            className="w-full bg-white rounded border border-gray-300 focus:border-blue-600 focus:ring-2 focus:ring-indigo-200 text-base outline-none text-gray-700 py-1 px-3 leading-8 transition-colors duration-200 ease-in-out"
-            placeholder="本のタイトルを入力してください"
-          />
-          <button className="w-20 text-white bg-blue-600 border-0 py-2 px-4 focus:outline-none hover:bg-blue-600 rounded text-md">
-            検索
-          </button>
-        </form>
-        　
-        <div className="pt-8">
-          <p>検索結果</p>
+        <div className="pt-10">
+          <h1>検索結果</h1>
           <div className="grid grid-cols-2 gap-4 bg-grey-light py-8 w-full @screen sm:grid-cols-4">
             <div className="bg-white rounded w-1/8 shadow hover:shadow-md duration-4">
               <div className="p-2 text-grey-darker text-justify flex flex-col">

--- a/public/images/arrow-left.svg
+++ b/public/images/arrow-left.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="white">
+  <path fill-rule="evenodd" d="M9.707 16.707a1 1 0 01-1.414 0l-6-6a1 1 0 010-1.414l6-6a1 1 0 011.414 1.414L5.414 9H17a1 1 0 110 2H5.414l4.293 4.293a1 1 0 010 1.414z" clip-rule="evenodd" />
+</svg>

--- a/public/images/search.svg
+++ b/public/images/search.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="white">
+  <path fill-rule="evenodd" d="M8 4a4 4 0 100 8 4 4 0 000-8zM2 8a6 6 0 1110.89 3.476l4.817 4.817a1 1 0 01-1.414 1.414l-4.816-4.816A6 6 0 012 8z" clip-rule="evenodd" />
+</svg>


### PR DESCRIPTION
fix #19 
## 実装内容
- 検索結果画面の検索欄を除外
- 検索欄をヘッダーに設置
- 検索欄は
  - PCサイズ：入力欄と検索アイコン(虫眼鏡)
  - スマホサイズ：
    - デフォルト：検索アイコンのみ
    - アイコン押下時：デフォルトに戻るアイコン(左矢印)、入力欄、検索アイコン
 
## イメージ

https://user-images.githubusercontent.com/66728424/107845400-69eac580-6e1e-11eb-94a7-650237088f50.mov

ご確認お願いします！