### PR TITLE
fix(library):マイライブラリのコンポーネント化

### DIFF
--- a/components/LibraryCard.tsx
+++ b/components/LibraryCard.tsx
@@ -1,0 +1,63 @@
+import * as React from 'react';
+import LibraryMemory from '../components/LibraryMemory';
+
+type Props = {
+  bid: number;
+  imgUrl: string;
+  title: string;
+};
+
+const textMemorys = [
+  {
+    id: 0,
+    texts: [],
+  },
+  {
+    id: 1,
+    texts: [
+      'Lorem ipsum dolor, sit amet consectetur adipisicing elit.Quam quidem laborum, quae impedit laboriosam dolore nemorecusandae, iusto blanditiis soluta omnis hic magni sit? Expedita!',
+      'Quo officia perspiciatis accusamus aliquam repellendus optio vel ipsum cupiditate tenetur hic voluptate fugit laudantium quod aliquid itaque quasi enim, dicta ducimus.',
+    ],
+  },
+  {
+    id: 2,
+    texts: [
+      'Lorem ipsum dolor, sit amet consectetur adipisicing elit.Quam quidem laborum, quae impedit laboriosam dolore nemorecusandae, iusto blanditiis soluta omnis hic magni sit? Expedita!',
+      'Quo officia perspiciatis accusamus aliquam repellendus optio vel ipsum cupiditate tenetur hic voluptate fugit laudantium quod aliquid itaque quasi enim, dicta ducimus.',
+      'laudantium quod aliquid itaque quasi enim, dicta ducimus.',
+    ],
+  },
+];
+
+const LibraryCard = ({ bid, imgUrl, title }: Props) => (
+  <div className='p-1 flex flex-col bg-white rounded w-full shadow hover:shadow-md duration-4'>
+    <div className='relative p-1 flex'>
+      <img
+        src={imgUrl}
+        alt='Some image'
+        className='w-8 flex self-center shadow-lg'
+      />
+      <p className='p-1 font-bold text-sm'>{title}</p>
+      <a href='#' className='ml-2 flex-shrink-0'>
+        <img
+          src='/images/dots.svg'
+          alt=''
+          className='w-4 rounded-md absolute top-0 right-0 opacity-30'
+        />
+      </a>
+    </div>
+    <form className='mt-1 text-sm text-gray-900 sm:mt-0 sm:col-span-2'>
+      <ul className='border border-gray-200 rounded-md divide-y divide-gray-200'>
+        {textMemorys.map(
+          (textMemory) =>
+            bid === textMemory.id && (
+              <div key={textMemory.id}>
+                <LibraryMemory texts={textMemory.texts} />
+              </div>
+            )
+        )}
+      </ul>
+    </form>
+  </div>
+);
+export default LibraryCard;

--- a/components/LibraryCard.tsx
+++ b/components/LibraryCard.tsx
@@ -7,7 +7,7 @@ type Props = {
   title: string;
 };
 
-const textMemorys = [
+const textMemories = [
   {
     id: 0,
     texts: [],
@@ -48,7 +48,7 @@ const LibraryCard = ({ bid, imgUrl, title }: Props) => (
     </div>
     <form className='mt-1 text-sm text-gray-900 sm:mt-0 sm:col-span-2'>
       <ul className='border border-gray-200 rounded-md divide-y divide-gray-200'>
-        {textMemorys.map(
+        {textMemories.map(
           (textMemory) =>
             bid === textMemory.id && (
               <div key={textMemory.id}>

--- a/components/LibraryMemory.tsx
+++ b/components/LibraryMemory.tsx
@@ -1,0 +1,45 @@
+import * as React from 'react';
+
+type Props = {
+  texts?: string[];
+};
+
+const textAreaHeightSet = () => {};
+
+const LibraryMemory = ({ texts }: Props) => (
+  <>
+    {texts &&
+      texts.map((text) => (
+        <li key={text} className='p-1 items-center text-sm'>
+          <div className='flex p-1 border-b-2 border-gray-100 rounded-md'>
+            <p
+              className='ml-1 rounded-md flex-1 resize-none bg-white'
+              onInput={textAreaHeightSet}
+            >
+              {text}
+            </p>
+
+            <div className='ml-2 flex flex-col relative'>
+              <a href='#' className='pb-1 flex-shrink-0' id='options-menu'>
+                <img src='/images/dots.svg' alt='' className='w-4 opacity-30' />
+              </a>
+            </div>
+          </div>
+        </li>
+      ))}
+    <li className='p-2 items-center text-sm'>
+      <div className='flex relative'>
+        <textarea
+          wrap='hard'
+          placeholder='入力する'
+          className='ml-2 mr-6 flex-1 resize-none focus:outline-none'
+        ></textarea>
+
+        <a href='#' className='flex-shrink-0 absolute bottom-0 right-0'>
+          <img src='/images/check.svg' alt='' className='w-4' />
+        </a>
+      </div>
+    </li>
+  </>
+);
+export default LibraryMemory;

--- a/pages/library.tsx
+++ b/pages/library.tsx
@@ -1,116 +1,41 @@
-import Layout from "../components/Layout";
+import Layout from '../components/Layout';
+import LibraryCard from '../components/LibraryCard';
+import React from 'react';
 
 export default function Library() {
+  const books = [
+    {
+      id: 0,
+      imgUrl: 'https://picsum.photos/25/40',
+      title: 'A Lorem ipsum dolor sit amet.',
+    },
+    {
+      id: 1,
+      imgUrl: 'https://picsum.photos/25/40',
+      title: 'B Lorem ipsum dolor sit amet.',
+    },
+    {
+      id: 2,
+      imgUrl: 'https://picsum.photos/25/40',
+      title: 'C Lorem ipsum dolor sit amet.',
+    },
+  ];
+
   return (
     <Layout>
-      <div className="py-16 px-2">
-        <h2 className="pt-8">マイライブラリ</h2>
-        <div className="grid gap-4 bg-grey-light p-4 w-full">
-          <div className="p-1 flex flex-col bg-white rounded w-full shadow hover:shadow-md duration-4">
-            <div className="relative p-1 text-grey-darker flex">
-              <img
-                src="https://picsum.photos/25/40"
-                alt="Some image"
-                className="w-8 flex self-center shadow-lg"
-              />
-              <p className="p-1 font-bold text-sm">
-                Lorem ipsum dolor sit amet.
-              </p>
-              <a href="#" className="ml-2 flex-shrink-0">
-                <img
-                  src="/images/dots.svg"
-                  alt=""
-                  className="w-4 rounded-md absolute top-0 right-0 opacity-30"
-                />
-              </a>
-            </div>
-            <form className="mt-1 text-sm text-gray-900 sm:mt-0 sm:col-span-2">
-              <ul className="border border-gray-200 rounded-md divide-y divide-gray-200">
-                <li className="p-2 items-center text-sm">
-                  <div className="flex relative">
-                    <textarea
-                      wrap="hard"
-                      placeholder="入力する"
-                      className="ml-2 mr-6 flex-1 resize-none focus:outline-none"
-                    ></textarea>
-
-                    <a
-                      href="#"
-                      className="flex-shrink-0 absolute bottom-0 right-0"
-                    >
-                      <img src="/images/check.svg" alt="" className="w-4" />
-                    </a>
-                  </div>
-                </li>
-              </ul>
-            </form>
-          </div>
-          <div className="p-1 flex flex-col bg-white rounded w-full shadow hover:shadow-md duration-4">
-            <div className="relative p-1 text-grey-darker flex">
-              <img
-                src="https://picsum.photos/25/40"
-                alt="Some image"
-                className="w-8 flex self-center shadow-lg"
-              />
-              <p className="p-1 font-bold text-sm">
-                Lorem ipsum dolor sit amet.
-              </p>
-              <a href="#" className="ml-2 flex-shrink-0">
-                <img
-                  src="/images/dots.svg"
-                  alt=""
-                  className="w-4 rounded-md absolute top-0 right-0 opacity-30"
-                />
-              </a>
-            </div>
-            <form className="mt-1 text-sm text-gray-900 sm:mt-0 sm:col-span-2">
-              <ul className="border border-gray-200 rounded-md divide-y divide-gray-200">
-                <li className="p-2 items-center text-sm">
-                  <div className="flex">
-                    <textarea
-                      disabled
-                      wrap="hard"
-                      className="ml-1 flex-1 resize-none"
-                    >
-                      Lorem ipsum dolor, sit amet consectetur adipisicing elit.
-                      Quam quidem laborum, quae impedit laboriosam dolore nemo
-                      recusandae, iusto blanditiis soluta omnis hic magni sit?
-                      Expedita!
-                    </textarea>
-                    <div className="ml-2 flex flex-col relative">
-                      <a
-                        href="#"
-                        className="pb-1 flex-shrink-0"
-                        id="options-menu"
-                      >
-                        <img
-                          src="/images/dots.svg"
-                          alt=""
-                          className="w-4 opacity-30"
-                        />
-                      </a>
-                    </div>
-                  </div>
-                </li>
-                <li className="p-2 items-center text-sm">
-                  <div className="flex relative">
-                    <textarea
-                      wrap="hard"
-                      placeholder="入力する"
-                      className="ml-2 mr-6 flex-1 resize-none focus:outline-none"
-                    ></textarea>
-
-                    <a
-                      href="#"
-                      className="flex-shrink-0 absolute bottom-0 right-0"
-                    >
-                      <img src="/images/check.svg" alt="" className="w-4" />
-                    </a>
-                  </div>
-                </li>
-              </ul>
-            </form>
-          </div>
+      <div className='py-16 px-2'>
+        <h2 className='pt-8'>マイライブラリ</h2>
+        <div className='grid gap-4 bg-grey-light p-4 w-full'>
+          {books &&
+            books.map((book) => (
+              <div key={book.id}>
+                <LibraryCard
+                  bid={book.id}
+                  imgUrl={book.imgUrl}
+                  title={book.title}
+                ></LibraryCard>
+              </div>
+            ))}
         </div>
       </div>
     </Layout>


### PR DESCRIPTION
fix #13 
## 実装内容
- マイライブラリのコンポーネント化
　（元々１ページに書いていましたが、カード部分とテキスト部分をコンポーネント化しました）
- 入力内容の表示部分をtextarea→pタグに変更
※　機能は実装していないです

## イメージ（見た目は以前と変更なしです）
![image](https://user-images.githubusercontent.com/66728424/107926767-722b3800-6fb9-11eb-9c7c-b72e238ca0a6.png)

ご確認お願いします！