### PR TITLE
feature(Menu):ログアウト機能他画面遷移など

### DIFF
--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -3,6 +3,7 @@ import Link from 'next/link';
 import Head from 'next/head';
 import { AuthContext } from '../pages/_app';
 import LoginDialogButton from '../components/LoginDialogButton';
+import MenuVar from '../components/MenuVar';
 
 type Props = {
   children?: ReactNode;
@@ -24,7 +25,7 @@ const Layout = ({ children, title = 'ブックメモリー' }: Props) => {
         <meta charSet='utf-8' />
         <meta name='viewport' content='initial-scale=1.0, width=device-width' />
       </Head>
-      <header className='fixed top-0 -inset-x-0 bg-blue-600 p-2 px-4 flex justify-between items-center md:space-x-2'>
+      <header className='fixed top-0 -inset-x-0 bg-blue-600 p-2 px-4 flex justify-between items-center md:space-x-2 z-50'>
         <a className='text-white text-base'>LOGO</a>
         <div className='ml-4 items-center hidden w-1/2 sm:flex'>
           <input
@@ -60,13 +61,7 @@ const Layout = ({ children, title = 'ブックメモリー' }: Props) => {
             )
           ) : (
             //ログイン情報取得済のパターン（アイコン表示）
-            <a href='#'>
-              <img
-                src={currentUser?.photoURL || 'https://picsum.photos/100/100'}
-                alt='Some image'
-                className='ml-4 rounded-full h-9 w-9 flex items-center justify-center'
-              />
-            </a>
+            <MenuVar />
           )}
         </div>
       </header>
@@ -97,11 +92,15 @@ const Layout = ({ children, title = 'ブックメモリー' }: Props) => {
         </div>
       )}
 
-      <main>{children}</main>
+      <main className='container mx-auto px-16'>{children}</main>
       <footer className='pt-10 pb-8 bg-gray-50'>
         <div className='flex flex-wrap justify-center space-x-4'>
-          <a href='#'>利用規約</a>
-          <a href='#'>プライバシーポリシー</a>
+          <Link href='/terms'>
+            <a>利用規約</a>
+          </Link>
+          <Link href='/privacypolicy'>
+            <a>プライバシーポリシー</a>
+          </Link>
           <a href='#'>お問合せ</a>
         </div>
         <p className='text-center m-4'>©️E-LOVE</p>

--- a/components/MenuVar.tsx
+++ b/components/MenuVar.tsx
@@ -1,0 +1,87 @@
+import Menu from '@material-ui/core/Menu';
+import MenuItem from '@material-ui/core/MenuItem';
+import ListItemIcon from '@material-ui/core/ListItemIcon';
+import LibraryBooksIcon from '@material-ui/icons/LibraryBooks';
+import SettingsIcon from '@material-ui/icons/Settings';
+import ExitToAppIcon from '@material-ui/icons/ExitToApp';
+import Typography from '@material-ui/core/Typography';
+import { makeStyles } from '@material-ui/core/styles';
+import { useContext, useState } from 'react';
+import { AuthContext } from '../pages/_app';
+import Router from 'next/router';
+import { auth } from '../utils/firebase';
+
+const useStyles = makeStyles({
+  root: {
+    minWidth: 32,
+  },
+});
+const MenuVar = () => {
+  const currentUser = useContext(AuthContext).currentUser;
+  const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
+  const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+    setAnchorEl(event.currentTarget);
+  };
+  const handleClose = () => {
+    setAnchorEl(null);
+  };
+
+  const onClickMyLibrary = () => {
+    Router.push('/library');
+  };
+  const onClickUserSetting = () => {
+    Router.push('/setting');
+  };
+  const onClickLogout = () => {
+    Router.push('/');
+    auth.signOut();
+  };
+
+  const classes = useStyles();
+
+  return (
+    <div>
+      <button
+        className='focus:outline-none'
+        aria-controls='simple-menu'
+        aria-haspopup='true'
+        onClick={handleClick}
+      >
+        <img
+          src={currentUser?.photoURL || 'https://picsum.photos/100/100'}
+          alt='Some image'
+          className='ml-4 rounded-full h-9 w-9 flex items-center justify-center'
+        />
+      </button>
+      <Menu
+        id='simple-menu'
+        anchorEl={anchorEl}
+        keepMounted
+        open={Boolean(anchorEl)}
+        onClose={handleClose}
+      >
+        <MenuItem onClick={onClickMyLibrary}>
+          <ListItemIcon classes={classes}>
+            <LibraryBooksIcon fontSize='small' />
+          </ListItemIcon>
+          <Typography variant='inherit'>マイライブラリ</Typography>
+        </MenuItem>
+        <MenuItem onClick={onClickUserSetting}>
+          <ListItemIcon classes={classes}>
+            <SettingsIcon fontSize='small' />
+          </ListItemIcon>
+          <Typography variant='inherit'>ユーザー設定</Typography>
+        </MenuItem>
+        <MenuItem onClick={onClickLogout}>
+          <ListItemIcon classes={classes}>
+            <ExitToAppIcon fontSize='small' />
+          </ListItemIcon>
+          <Typography variant='inherit' noWrap>
+            ログアウト
+          </Typography>
+        </MenuItem>
+      </Menu>
+    </div>
+  );
+};
+export default MenuVar;


### PR DESCRIPTION
fix #27 #28 #29 #31 #32 

## 実装内容
- ログインアイコンのメニューバー実装
- ログアウト機能、ログアウト後ウェルカム画面遷移
- 他画面遷移（ヘッダー：マイライブラリ、ユーザー設定、フッター：利用規約、プライバシーポリシー）

## アイコンメニューバーイメージ
![image](https://user-images.githubusercontent.com/66728424/109961746-b0508780-7d2d-11eb-9d46-da5adb57663e.png)

## ログアウトイメージ
![Logout](https://user-images.githubusercontent.com/66728424/109961556-767f8100-7d2d-11eb-9f1e-44eed9571ef7.gif)

ご確認宜しくお願いします！