### PR TITLE
feature(LibraryCard&memory):メモリーをFirebase追加＆取得

### DIFF
--- a/components/LibraryCard.tsx
+++ b/components/LibraryCard.tsx
@@ -1,9 +1,10 @@
 import React, { useEffect, useState } from 'react';
 import LibraryMemory from '../components/LibraryMemory';
 import MoreVar from '../components/MoreVer';
+import { createMemory, useMemory } from '../utils/memory';
 
 type Props = {
-  bid: number;
+  bid: string;
   imgUrl: string;
   title: string;
   texts: string[];
@@ -11,23 +12,20 @@ type Props = {
 
 const LibraryCard = ({ bid, imgUrl, title, texts }: Props) => {
   const onBookDelete = () => {};
+  const memories = useMemory(bid);
+  //入力メモリーのステイト
   const [input, setInput] = useState('');
-  const [memories, setMemory] = useState(texts);
+  //メモリー入力中関数
   const onChangeInput: any = (event: React.ChangeEvent<HTMLInputElement>) => {
     setInput(event.target.value);
-    console.log(typeof event.target);
   };
-  //記録追加関数
+  //メモリー追加関数
   const onClickMemoryAdd: VoidFunction = () => {
     if (input === '') return;
-    const newText = [...memories, input];
-    setMemory(newText);
+    const newMemories: any = [...memories, input];
+    createMemory(bid, newMemories);
     setInput('');
   };
-
-  useEffect(() => {
-    console.log(memories);
-  });
 
   return (
     <div className='p-1 flex flex-col bg-blue-100 rounded w-full shadow hover:shadow-md duration-4'>

--- a/utils/memory.tsx
+++ b/utils/memory.tsx
@@ -1,0 +1,28 @@
+import 'firebase/auth';
+import 'firebase/firestore';
+import firebase from 'firebase/app';
+import { useEffect, useState } from 'react';
+
+//Firebase上のメモリー監視用フック
+//変更があったタイミングで対象本のメモリーを返却
+export const useMemory = (id: string) => {
+  const [memories, setMemory] = useState<any>();
+  useEffect(() => {
+    firebase
+      .firestore()
+      .doc(`books/${id}`)
+      .onSnapshot((snap) => {
+        setMemory(snap.data()?.memories || []);
+      });
+  }, []);
+  return memories;
+};
+
+//メモリー登録
+//配列丸ごと更新させる
+export const createMemory = (id: string, newMemories: string) => {
+  console.log(id);
+  return firebase.firestore().doc(`books/${id}`).update({
+    memories: newMemories,
+  });
+};


### PR DESCRIPTION
fix #44 
## 実装内容
- メモリーをFIrebaseから取得
- メモリーをFirebaseに登録
arrayUnionでは同じ本のメモリー(配列)上で同値はセットできなかったので、配列を丸ごと更新するようにしました。（memory.tsxの26行目）また、入力上限チェック処理は別途実装します。

## イメージ
![Library-Input-Firebase](https://user-images.githubusercontent.com/66728424/110450496-997fab80-8106-11eb-93a4-4b486d7ca944.gif)

ご確認宜しくお願いいたします！