### PR TITLE
feature(Library):メモリー削除機能

### DIFF
--- a/components/LibraryCard.tsx
+++ b/components/LibraryCard.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import LibraryMemory from '../components/LibraryMemory';
-import MoreVar from '../components/MoreVer';
-import { createMemory, useMemory } from '../utils/memory';
+import MoreVar from './MoreVar';
+import { newMemory, useMemory } from '../utils/memory';
 
 type Props = {
   bid: string;
@@ -11,7 +11,12 @@ type Props = {
 };
 
 const LibraryCard = ({ bid, imgUrl, title, texts }: Props) => {
-  const onBookDelete = () => {};
+  const actions = [
+    {
+      label: 'ライブラリ削除',
+      function: () => {},
+    },
+  ];
   const memories = useMemory(bid);
   //入力メモリーのステイト
   const [input, setInput] = useState('');
@@ -23,7 +28,7 @@ const LibraryCard = ({ bid, imgUrl, title, texts }: Props) => {
   const onClickMemoryAdd: VoidFunction = () => {
     if (input === '') return;
     const newMemories: any = [...memories, input];
-    createMemory(bid, newMemories);
+    newMemory(bid, newMemories);
     setInput('');
   };
 
@@ -37,15 +42,13 @@ const LibraryCard = ({ bid, imgUrl, title, texts }: Props) => {
         />
         <p className='p-2 font-semibold text-sm text-center'>{title}</p>
         <div className='ml-2 absolute top-0 right-0'>
-          <MoreVar
-            onFunctions={[onBookDelete]}
-            children={['ライブラリから削除']}
-          />
+          <MoreVar actions={actions} />
         </div>
       </div>
       <form className='mt-1 text-sm text-gray-900 sm:mt-0 sm:col-span-2'>
         <ul className='border border-gray-200 rounded-md divide-y divide-gray-200'>
           <LibraryMemory
+            bid={bid}
             input={input}
             onChange={onChangeInput}
             onClick={onClickMemoryAdd}

--- a/components/LibraryCard.tsx
+++ b/components/LibraryCard.tsx
@@ -1,7 +1,7 @@
-import React, { useEffect, useState } from 'react';
+import React, { ChangeEvent, useEffect, useState } from 'react';
 import LibraryMemory from '../components/LibraryMemory';
 import MoreVar from './MoreVar';
-import { newMemory, useMemory } from '../utils/memory';
+import { addMemory, useMemory } from '../utils/memory';
 
 type Props = {
   bid: string;
@@ -21,14 +21,14 @@ const LibraryCard = ({ bid, imgUrl, title, texts }: Props) => {
   //入力メモリーのステイト
   const [input, setInput] = useState('');
   //メモリー入力中関数
-  const onChangeInput: any = (event: React.ChangeEvent<HTMLInputElement>) => {
+  const onChangeInput: any = (event: ChangeEvent<HTMLInputElement>) => {
     setInput(event.target.value);
   };
   //メモリー追加関数
   const onClickMemoryAdd: VoidFunction = () => {
     if (input === '') return;
-    const newMemories: any = [...memories, input];
-    newMemory(bid, newMemories);
+    memories.push(input);
+    addMemory(bid, memories);
     setInput('');
   };
 

--- a/components/LibraryMemory.tsx
+++ b/components/LibraryMemory.tsx
@@ -1,18 +1,16 @@
 import React from 'react';
-import MoreVar from '../components/MoreVer';
+import MemoryMoreVart from './MemoryMoreVart';
 import IconButton from '@material-ui/core/IconButton';
 import CheckOutlinedIcon from '@material-ui/icons/CheckOutlined';
 type Props = {
+  bid: string;
   input: string;
   onChange: VoidFunction;
   onClick: VoidFunction;
   memories?: string[];
 };
 
-const LibraryMemory = ({ input, onChange, onClick, memories }: Props) => {
-  const onMemoryEdit = () => {};
-  const onMemoryDelete = () => {};
-
+const LibraryMemory = ({ bid, input, onChange, onClick, memories }: Props) => {
   return (
     <>
       {memories &&
@@ -26,10 +24,7 @@ const LibraryMemory = ({ input, onChange, onClick, memories }: Props) => {
                 {memory}
               </p>
 
-              <MoreVar
-                onFunctions={[onMemoryEdit, onMemoryDelete]}
-                children={['編集', '削除']}
-              />
+              <MemoryMoreVart bid={bid} memoryIndex={index} memory={memory} />
             </div>
           </li>
         ))}

--- a/components/MemoryMoreVart.tsx
+++ b/components/MemoryMoreVart.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { MouseEvent, useEffect, useState } from 'react';
 import Menu from '@material-ui/core/Menu';
 import MenuItem from '@material-ui/core/MenuItem';
 import IconButton from '@material-ui/core/IconButton';
@@ -8,7 +8,7 @@ import Typography from '@material-ui/core/Typography';
 import { makeStyles } from '@material-ui/core/styles';
 import EditOutlinedIcon from '@material-ui/icons/EditOutlined';
 import DeleteOutlineIcon from '@material-ui/icons/DeleteOutline';
-import { useMemory, newMemory } from '../utils/memory';
+import { useMemory, addMemory } from '../utils/memory';
 
 type Props = {
   bid: string;
@@ -24,8 +24,8 @@ const useStyles = makeStyles({
 
 const MemoryMoreVert = ({ bid, memoryIndex, memory }: Props) => {
   const memories = useMemory(bid);
-  const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
-  const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+  const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
+  const handleClick = (event: MouseEvent<HTMLButtonElement>) => {
     setAnchorEl(event.currentTarget);
   };
   const handleClose = () => {
@@ -33,9 +33,8 @@ const MemoryMoreVert = ({ bid, memoryIndex, memory }: Props) => {
   };
   const onClickEditMemory = () => {};
   const onClickDeleteMemory = (index: number) => {
-    const newMemories: any = [...memories];
-    newMemories.splice(index, 1);
-    newMemory(bid, newMemories);
+    memories.splice(index, 1);
+    addMemory(bid, memories);
     handleClose();
   };
   const classes = useStyles();

--- a/components/MemoryMoreVart.tsx
+++ b/components/MemoryMoreVart.tsx
@@ -1,0 +1,77 @@
+import React, { useEffect } from 'react';
+import Menu from '@material-ui/core/Menu';
+import MenuItem from '@material-ui/core/MenuItem';
+import IconButton from '@material-ui/core/IconButton';
+import MoreVertIcon from '@material-ui/icons/MoreVert';
+import { ListItemIcon } from '@material-ui/core';
+import Typography from '@material-ui/core/Typography';
+import { makeStyles } from '@material-ui/core/styles';
+import EditOutlinedIcon from '@material-ui/icons/EditOutlined';
+import DeleteOutlineIcon from '@material-ui/icons/DeleteOutline';
+import { useMemory, newMemory } from '../utils/memory';
+
+type Props = {
+  bid: string;
+  memoryIndex: number;
+  memory: string;
+};
+
+const useStyles = makeStyles({
+  root: {
+    minWidth: 32,
+  },
+});
+
+const MemoryMoreVert = ({ bid, memoryIndex, memory }: Props) => {
+  const memories = useMemory(bid);
+  const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
+  const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+    setAnchorEl(event.currentTarget);
+  };
+  const handleClose = () => {
+    setAnchorEl(null);
+  };
+  const onClickEditMemory = () => {};
+  const onClickDeleteMemory = (index: number) => {
+    const newMemories: any = [...memories];
+    newMemories.splice(index, 1);
+    newMemory(bid, newMemories);
+    handleClose();
+  };
+  const classes = useStyles();
+  return (
+    <div className='ml-2 flex flex-col'>
+      <IconButton
+        aria-label='more'
+        aria-controls='simple-menu'
+        aria-haspopup='true'
+        onClick={handleClick}
+        className='opacity-0 group-hover:opacity-40 hover:bg-white hover:outline-none focus:outline-none'
+        style={{ padding: 0 }}
+      >
+        <MoreVertIcon />
+      </IconButton>
+      <Menu
+        id='simple-menu'
+        anchorEl={anchorEl}
+        keepMounted
+        open={Boolean(anchorEl)}
+        onClose={handleClose}
+      >
+        <MenuItem onClick={onClickEditMemory}>
+          <ListItemIcon classes={classes}>
+            <EditOutlinedIcon fontSize='small' />
+          </ListItemIcon>
+          <Typography variant='inherit'>編集</Typography>
+        </MenuItem>
+        <MenuItem onClick={() => onClickDeleteMemory(memoryIndex)}>
+          <ListItemIcon classes={classes}>
+            <DeleteOutlineIcon fontSize='small' />
+          </ListItemIcon>
+          <Typography variant='inherit'>削除</Typography>
+        </MenuItem>
+      </Menu>
+    </div>
+  );
+};
+export default MemoryMoreVert;

--- a/components/MoreVar.tsx
+++ b/components/MoreVar.tsx
@@ -5,11 +5,13 @@ import IconButton from '@material-ui/core/IconButton';
 import MoreVertIcon from '@material-ui/icons/MoreVert';
 
 type Props = {
-  onFunctions: VoidFunction[];
-  children: string[];
+  actions: {
+    label: string;
+    function: VoidFunction;
+  }[];
 };
 
-const MoreVer = ({ onFunctions, children }: Props) => {
+const MoreVer = ({ actions }: Props) => {
   const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
   const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
     setAnchorEl(event.currentTarget);
@@ -36,10 +38,10 @@ const MoreVer = ({ onFunctions, children }: Props) => {
         open={Boolean(anchorEl)}
         onClose={handleClose}
       >
-        {onFunctions &&
-          onFunctions.map((onFunction, idx) => (
+        {actions &&
+          actions.map((action, idx) => (
             <div key={idx}>
-              <MenuItem onClick={onFunction}>{children[idx]}</MenuItem>
+              <MenuItem onClick={action.function}>{action.label}</MenuItem>
             </div>
           ))}
       </Menu>

--- a/utils/memory.tsx
+++ b/utils/memory.tsx
@@ -20,7 +20,7 @@ export const useMemory = (id: string) => {
 
 //メモリー作成（追加、編集、削除、全てこの関数で行う）
 //配列丸ごと更新させる
-export const newMemory = (id: string, newMemories: string) => {
+export const addMemory = (id: string, newMemories: string) => {
   return firebase.firestore().doc(`books/${id}`).update({
     memories: newMemories,
   });

--- a/utils/memory.tsx
+++ b/utils/memory.tsx
@@ -18,10 +18,9 @@ export const useMemory = (id: string) => {
   return memories;
 };
 
-//メモリー登録
+//メモリー作成（追加、編集、削除、全てこの関数で行う）
 //配列丸ごと更新させる
-export const createMemory = (id: string, newMemories: string) => {
-  console.log(id);
+export const newMemory = (id: string, newMemories: string) => {
   return firebase.firestore().doc(`books/${id}`).update({
     memories: newMemories,
   });


### PR DESCRIPTION
fix #43 
## 実装内容
- メモリー削除機能（Firebaseから削除）
arrayRemoveでは仮に同値が入力されていた場合、１レコード削除したら他の同値のレコードも削除されてしまう。
（例えば、１レコード：AAA、２レコード：AAA　の場合、２レコード目を削除しようとしたら、同値の２レコード目も削除されてしまう）
そのため、都度配列を新しく作ってupdateをする。
- 細かい名称変更（関数名、ファイル名等）

## イメージ
![Library-Delete-Firebase](https://user-images.githubusercontent.com/66728424/110713119-b4583a00-8244-11eb-8f45-92b364bf70ae.gif)
