### PR TITLE
feature(ライブラリ画面):メモリー編集機能

### DIFF
--- a/components/EditMemoryDialog.tsx
+++ b/components/EditMemoryDialog.tsx
@@ -8,7 +8,7 @@ type Props = {
   open: boolean;
   onClickEditMemory: any;
   onChangeEditMemory: any;
-  handleClose: VoidFunction;
+  closeHandle: VoidFunction;
   memoryIndex: number;
   editInput: string;
 };
@@ -17,7 +17,7 @@ const EditMemoryDialog = ({
   open,
   onClickEditMemory,
   onChangeEditMemory,
-  handleClose,
+  closeHandle,
   editInput,
   memoryIndex,
 }: Props) => {
@@ -25,7 +25,7 @@ const EditMemoryDialog = ({
     <div>
       <Dialog
         open={open}
-        onClose={handleClose}
+        onClose={closeHandle}
         aria-labelledby='form-dialog-title'
         maxWidth='lg'
         scroll='body'
@@ -46,7 +46,7 @@ const EditMemoryDialog = ({
         </DialogContent>
         <DialogActions>
           <button
-            onClick={handleClose}
+            onClick={closeHandle}
             className='bg-gray-200 p-2 mr-1 rounded-md '
           >
             キャンセル

--- a/components/EditMemoryDialog.tsx
+++ b/components/EditMemoryDialog.tsx
@@ -1,0 +1,67 @@
+import React from 'react';
+import TextField from '@material-ui/core/TextField';
+import Dialog from '@material-ui/core/Dialog';
+import DialogActions from '@material-ui/core/DialogActions';
+import DialogContent from '@material-ui/core/DialogContent';
+
+type Props = {
+  open: boolean;
+  onClickEditMemory: any;
+  onChangeEditMemory: any;
+  handleClose: VoidFunction;
+  memoryIndex: number;
+  editInput: string;
+};
+
+const EditMemoryDialog = ({
+  open,
+  onClickEditMemory,
+  onChangeEditMemory,
+  handleClose,
+  editInput,
+  memoryIndex,
+}: Props) => {
+  return (
+    <div>
+      <Dialog
+        open={open}
+        onClose={handleClose}
+        aria-labelledby='form-dialog-title'
+        maxWidth='lg'
+        scroll='body'
+        fullWidth={true}
+      >
+        <DialogContent>
+          <TextField
+            id='outlined-multiline-static'
+            label='編集'
+            multiline
+            rows={8}
+            onChange={onChangeEditMemory}
+            value={editInput}
+            variant='outlined'
+            size='medium'
+            fullWidth={true}
+          />
+        </DialogContent>
+        <DialogActions>
+          <button
+            onClick={handleClose}
+            className='bg-gray-200 p-2 mr-1 rounded-md '
+          >
+            キャンセル
+          </button>
+          <button
+            onClick={() => {
+              onClickEditMemory(memoryIndex);
+            }}
+            className='bg-green-500 text-white p-2 mr-1 rounded-md '
+          >
+            更新
+          </button>
+        </DialogActions>
+      </Dialog>
+    </div>
+  );
+};
+export default EditMemoryDialog;

--- a/components/LibraryMemory.tsx
+++ b/components/LibraryMemory.tsx
@@ -27,7 +27,7 @@ const LibraryMemory = ({ bid, input, onChange, onClick, memories }: Props) => {
               <MemoryMoreVart
                 bid={bid}
                 memoryIndex={index}
-                memories={memories}
+                memories={memories && memories}
               />
             </div>
           </li>

--- a/components/MemoryMoreVart.tsx
+++ b/components/MemoryMoreVart.tsx
@@ -29,7 +29,7 @@ const MemoryMoreVert = ({ bid, memoryIndex, memories }: Props) => {
   const onClickMoreVart = (event: MouseEvent<HTMLButtonElement>) => {
     setAnchorEl(event.currentTarget);
   };
-  const MoreVartClose = () => {
+  const closeMoreVart = () => {
     setAnchorEl(null);
   };
   // ーーー編集ダイアログ用ーーー //
@@ -42,7 +42,7 @@ const MemoryMoreVert = ({ bid, memoryIndex, memories }: Props) => {
   // 編集ダイアログ開く
   const onClickEditDialogOpen = () => {
     setEditDialogOpen(true);
-    MoreVartClose();
+    closeMoreVart();
   };
   // 編集ダイアログの入力ステート
   const [editInput, setEditInput] = useState(memories[memoryIndex]);
@@ -63,7 +63,7 @@ const MemoryMoreVert = ({ bid, memoryIndex, memories }: Props) => {
   const onClickDeleteMemory = (index: number) => {
     memories.splice(index, 1);
     addMemory(bid, memories);
-    MoreVartClose();
+    closeMoreVart();
   };
   const classes = useStyles();
   return (
@@ -83,7 +83,7 @@ const MemoryMoreVert = ({ bid, memoryIndex, memories }: Props) => {
         anchorEl={anchorEl}
         keepMounted
         open={Boolean(anchorEl)}
-        onClose={MoreVartClose}
+        onClose={closeMoreVart}
       >
         <MenuItem onClick={() => onClickEditDialogOpen()}>
           <ListItemIcon classes={classes}>
@@ -104,7 +104,7 @@ const MemoryMoreVert = ({ bid, memoryIndex, memories }: Props) => {
           open={editDialogopen}
           onClickEditMemory={onClickEditMemory}
           onChangeEditMemory={onChangeEditMemory}
-          handleClose={onClickDialogClose}
+          closeHandle={onClickDialogClose}
           editInput={editInput}
           memoryIndex={memoryIndex}
         />

--- a/components/MemoryMoreVart.tsx
+++ b/components/MemoryMoreVart.tsx
@@ -1,4 +1,4 @@
-import React, { MouseEvent, useState } from 'react';
+import React, { ChangeEvent, MouseEvent, useState } from 'react';
 import Menu from '@material-ui/core/Menu';
 import MenuItem from '@material-ui/core/MenuItem';
 import IconButton from '@material-ui/core/IconButton';
@@ -9,11 +9,12 @@ import { makeStyles } from '@material-ui/core/styles';
 import EditOutlinedIcon from '@material-ui/icons/EditOutlined';
 import DeleteOutlineIcon from '@material-ui/icons/DeleteOutline';
 import { addMemory } from '../utils/memory';
+import EditMemoryDialog from './EditMemoryDialog';
 
 type Props = {
   bid: string;
   memoryIndex: number;
-  memories?: string[];
+  memories: string[];
 };
 
 const useStyles = makeStyles({
@@ -23,18 +24,46 @@ const useStyles = makeStyles({
 });
 
 const MemoryMoreVert = ({ bid, memoryIndex, memories }: Props) => {
+  //　ーーーMoreVart用ーーー　//
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
-  const handleClick = (event: MouseEvent<HTMLButtonElement>) => {
+  const onClickMoreVart = (event: MouseEvent<HTMLButtonElement>) => {
     setAnchorEl(event.currentTarget);
   };
-  const handleClose = () => {
+  const MoreVartClose = () => {
     setAnchorEl(null);
   };
-  const onClickEditMemory = () => {};
-  const onClickDeleteMemory = (index: number) => {
-    memories?.splice(index, 1);
+  // ーーー編集ダイアログ用ーーー //
+  const [editDialogopen, setEditDialogOpen] = useState(false);
+  // 編集ダイアログ閉じる
+  const onClickDialogClose = () => {
+    setEditInput(memories[memoryIndex]);
+    setEditDialogOpen(false);
+  };
+  // 編集ダイアログ開く
+  const onClickEditDialogOpen = () => {
+    setEditDialogOpen(true);
+    MoreVartClose();
+  };
+  // 編集ダイアログの入力ステート
+  const [editInput, setEditInput] = useState(memories[memoryIndex]);
+  // 編集ダイアログのメモリー入力中関数
+  const onChangeEditMemory: any = (event: ChangeEvent<HTMLInputElement>) => {
+    setEditInput(event.target.value);
+  };
+  // メモリー更新関数
+  const onClickEditMemory = (index: number) => {
+    if (editInput === '') return;
+    memories[index] = editInput;
     addMemory(bid, memories);
-    handleClose();
+    setEditInput(memories[memoryIndex]);
+    setEditDialogOpen(false);
+  };
+
+  // メモリー削除関数
+  const onClickDeleteMemory = (index: number) => {
+    memories.splice(index, 1);
+    addMemory(bid, memories);
+    MoreVartClose();
   };
   const classes = useStyles();
   return (
@@ -43,7 +72,7 @@ const MemoryMoreVert = ({ bid, memoryIndex, memories }: Props) => {
         aria-label='more'
         aria-controls='simple-menu'
         aria-haspopup='true'
-        onClick={handleClick}
+        onClick={onClickMoreVart}
         className='opacity-0 group-hover:opacity-40 hover:bg-white hover:outline-none focus:outline-none'
         style={{ padding: 0 }}
       >
@@ -54,9 +83,9 @@ const MemoryMoreVert = ({ bid, memoryIndex, memories }: Props) => {
         anchorEl={anchorEl}
         keepMounted
         open={Boolean(anchorEl)}
-        onClose={handleClose}
+        onClose={MoreVartClose}
       >
-        <MenuItem onClick={onClickEditMemory}>
+        <MenuItem onClick={() => onClickEditDialogOpen()}>
           <ListItemIcon classes={classes}>
             <EditOutlinedIcon fontSize='small' />
           </ListItemIcon>
@@ -69,6 +98,17 @@ const MemoryMoreVert = ({ bid, memoryIndex, memories }: Props) => {
           <Typography variant='inherit'>削除</Typography>
         </MenuItem>
       </Menu>
+
+      {editDialogopen && (
+        <EditMemoryDialog
+          open={editDialogopen}
+          onClickEditMemory={onClickEditMemory}
+          onChangeEditMemory={onChangeEditMemory}
+          handleClose={onClickDialogClose}
+          editInput={editInput}
+          memoryIndex={memoryIndex}
+        />
+      )}
     </div>
   );
 };


### PR DESCRIPTION
fix #42 
## 実装内容
メモリーの編集機能
- モアバートの編集を押下すると編集用のダイアログが表示される
- 編集入力欄の初期値は編集前のテキスト
- ダイアログの更新を押下すると配列内の該当インデックスを更新し、配列丸ごとFirebaseに登録

## イメージ
![Edit-Library](https://user-images.githubusercontent.com/66728424/111550972-8df54a00-87c2-11eb-9c06-ccc1edfb4efe.gif)

ご確認宜しくお願いします！