### PR TITLE
feature(Library):メモリー上限チェック

### DIFF
--- a/components/LibraryCard.tsx
+++ b/components/LibraryCard.tsx
@@ -43,7 +43,7 @@ const LibraryCard = ({ bid, imgUrl, title }: Props) => {
     if (input.length > 1000) {
       setOpenSnackbar(true);
     }
-  });
+  }, [input.length]);
   //メモリー追加関数
   const onClickMemoryAdd: VoidFunction = () => {
     if (input === '') return;

--- a/components/LibraryCard.tsx
+++ b/components/LibraryCard.tsx
@@ -1,7 +1,9 @@
-import React, { ChangeEvent, useState } from 'react';
+import React, { ChangeEvent, SyntheticEvent, useEffect, useState } from 'react';
 import LibraryMemory from '../components/LibraryMemory';
 import MoreVar from './MoreVar';
 import { addMemory, useMemory } from '../utils/memory';
+import Snackbar from '@material-ui/core/Snackbar';
+import MuiAlert, { AlertProps } from '@material-ui/lab/Alert';
 
 type Props = {
   bid: string;
@@ -9,7 +11,19 @@ type Props = {
   title: string;
 };
 
+// Snacbar表示用↓
+function Alert(props: AlertProps) {
+  return <MuiAlert elevation={6} variant='filled' {...props} />;
+}
+
 const LibraryCard = ({ bid, imgUrl, title }: Props) => {
+  const [openSnackbar, setOpenSnackbar] = useState(false);
+  const closeSnackbar = (event?: SyntheticEvent, reason?: string) => {
+    if (reason === 'clickaway') {
+      return;
+    }
+    setOpenSnackbar(false);
+  };
   const actions = [
     {
       label: 'ライブラリ削除',
@@ -23,6 +37,13 @@ const LibraryCard = ({ bid, imgUrl, title }: Props) => {
   const onChangeInput: any = (event: ChangeEvent<HTMLInputElement>) => {
     setInput(event.target.value);
   };
+
+  //メモリーの上限(1000文字)監視フック
+  useEffect(() => {
+    if (input.length > 1000) {
+      setOpenSnackbar(true);
+    }
+  });
   //メモリー追加関数
   const onClickMemoryAdd: VoidFunction = () => {
     if (input === '') return;
@@ -55,6 +76,16 @@ const LibraryCard = ({ bid, imgUrl, title }: Props) => {
           />
         </ul>
       </form>
+
+      <Snackbar
+        open={openSnackbar}
+        autoHideDuration={1000}
+        onClose={closeSnackbar}
+      >
+        <Alert severity='error'>
+          １レコードの上限(1000文字)をオーバーしました
+        </Alert>
+      </Snackbar>
     </div>
   );
 };

--- a/components/LibraryMemory.tsx
+++ b/components/LibraryMemory.tsx
@@ -1,7 +1,8 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import MemoryMoreVart from './MemoryMoreVart';
 import IconButton from '@material-ui/core/IconButton';
 import CheckOutlinedIcon from '@material-ui/icons/CheckOutlined';
+
 type Props = {
   bid: string;
   input: string;
@@ -11,6 +12,14 @@ type Props = {
 };
 
 const LibraryMemory = ({ bid, input, onChange, onClick, memories }: Props) => {
+  //メモリー数上限監視フック
+  const [maxMemoryFlg, setMaxMemoryFlg] = useState(false);
+  useEffect(() => {
+    memories && memories.length >= 20
+      ? setMaxMemoryFlg(true)
+      : setMaxMemoryFlg(false);
+  });
+
   return (
     <>
       {memories &&
@@ -33,24 +42,32 @@ const LibraryMemory = ({ bid, input, onChange, onClick, memories }: Props) => {
           </li>
         ))}
       <li className='mx-4 items-center text-sm flex relative rounded-md bg-white'>
-        <textarea
-          wrap='hard'
-          value={input}
-          onChange={onChange}
-          placeholder='入力する'
-          className='ml-3 mr-7 p-1 rounded-md flex-1 resize-none focus:outline-none'
-        ></textarea>
+        {!maxMemoryFlg ? (
+          <>
+            <textarea
+              wrap='hard'
+              value={input}
+              onChange={onChange}
+              placeholder='入力する'
+              className='ml-3 mr-7 p-1 rounded-md flex-1 resize-none focus:outline-none'
+            ></textarea>
 
-        <div className='ml-2 absolute bottom-0 right-0 '>
-          <IconButton
-            className='focus:outline-none'
-            size='small'
-            style={{ color: 'green' }}
-            onClick={onClick}
-          >
-            <CheckOutlinedIcon fontSize='small' className='text-sm' />
-          </IconButton>
-        </div>
+            <div className='ml-2 absolute bottom-0 right-0 '>
+              <IconButton
+                className='focus:outline-none'
+                size='small'
+                style={{ color: 'green' }}
+                onClick={onClick}
+              >
+                <CheckOutlinedIcon fontSize='small' className='text-sm' />
+              </IconButton>
+            </div>
+          </>
+        ) : (
+          <div className='mx-auto text-center text-gray-500'>
+            １冊の上限(20レコード)に達しました
+          </div>
+        )}
       </li>
     </>
   );

--- a/components/LibraryMemory.tsx
+++ b/components/LibraryMemory.tsx
@@ -18,7 +18,7 @@ const LibraryMemory = ({ bid, input, onChange, onClick, memories }: Props) => {
     memories && memories.length >= 20
       ? setMaxMemoryFlg(true)
       : setMaxMemoryFlg(false);
-  });
+  }, [memories?.length]);
 
   return (
     <>


### PR DESCRIPTION
fix #64 

## 実装内容
- 1メモリー当たりの上限文字数(1000文字)チェック
  1000文字オーバーしたらスナックバー「１レコードの上限(1000文字)をオーバーしました」表示
- 1冊当たりのメモリー数の上限数(20メモリー)チェック
  20メモリーオーバーしたら入力欄を出さずに「１冊の上限(20レコード)に達しました」表示

## イメージ
1メモリー当たりの上限文字数(1000文字)チェック
![memory-error-1000](https://user-images.githubusercontent.com/66728424/111891855-6b209b00-8a39-11eb-97c4-8e56d0887111.gif)

1冊当たりのメモリー数の上限数(20メモリー)チェック
![memory-error-20](https://user-images.githubusercontent.com/66728424/111891975-601a3a80-8a3a-11eb-9e0b-f14f11e5a098.gif)

ご確認お願いします！