### PR TITLE
feature(firebase):swr-firestoreの導入、ログイン情報取得方法の変更、ユーザー単位での本登録

### DIFF
--- a/components/BookCard.tsx
+++ b/components/BookCard.tsx
@@ -3,8 +3,7 @@ import BookCardButton from '../components/BookCardButton';
 import Snackbar from '@material-ui/core/Snackbar';
 import MuiAlert, { AlertProps } from '@material-ui/lab/Alert';
 import { addBook } from '../utils/book';
-import { useContext } from 'react';
-import { AuthContext } from '../pages/_app';
+import { fuego } from '../utils/firebase';
 
 type Props = {
   bid: string;
@@ -17,7 +16,7 @@ function Alert(props: AlertProps) {
 }
 
 const BookCard = ({ bid, imgUrl, title }: Props) => {
-  const currentUser = useContext(AuthContext).currentUser;
+  const currentUser = fuego.auth().currentUser;
   // Snackbar表示ステイト
   const [openSnackbar, setOpenSnackbar] = useState(false);
   const closeSnackbar = () => {

--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -1,9 +1,9 @@
-import React, { ReactNode, useState, useContext } from 'react';
+import React, { ReactNode, useState } from 'react';
 import Link from 'next/link';
 import Head from 'next/head';
-import { AuthContext } from '../pages/_app';
 import LoginDialogButton from '../components/LoginDialogButton';
 import MenuVar from '../components/MenuVar';
+import { fuego } from '../utils/firebase';
 
 type Props = {
   children?: ReactNode;
@@ -11,13 +11,12 @@ type Props = {
 };
 
 const Layout = ({ children, title = 'ブックメモリー' }: Props) => {
-  const currentUser = useContext(AuthContext).currentUser;
+  const currentUser = fuego.auth().currentUser;
   const [searchBarVisible, setSearchBarVisible] = useState(false);
 
   const onClickSearchBarVisible = () => {
     setSearchBarVisible(!searchBarVisible);
   };
-
   return (
     <div>
       <Head>

--- a/components/LoginDialogButton.tsx
+++ b/components/LoginDialogButton.tsx
@@ -1,7 +1,7 @@
-import React, { useState, useContext } from 'react';
+import React, { useState } from 'react';
 import Router from 'next/router';
 import LoginDialog from '../components/LoginDialog';
-import { AuthContext } from '../pages/_app';
+import { fuego } from '../utils/firebase';
 
 type Props = {
   children: string;
@@ -9,11 +9,11 @@ type Props = {
 };
 
 const LoginDialogButton = ({ children, stylecss }: Props) => {
-  const auth = useContext(AuthContext);
+  const currentUser = fuego.auth().currentUser;
   const [open, setOpen] = useState(false);
   const handleClickOpen = () => {
     {
-      auth.currentUser ? Router.push('/library') : setOpen(true);
+      currentUser ? Router.push('/library') : setOpen(true);
     }
   };
   const handleClose = () => {

--- a/components/MenuVar.tsx
+++ b/components/MenuVar.tsx
@@ -6,10 +6,10 @@ import SettingsIcon from '@material-ui/icons/Settings';
 import ExitToAppIcon from '@material-ui/icons/ExitToApp';
 import Typography from '@material-ui/core/Typography';
 import { makeStyles } from '@material-ui/core/styles';
-import { useContext, useState } from 'react';
-import { AuthContext } from '../pages/_app';
+import { useState } from 'react';
 import Router from 'next/router';
 import { auth } from '../utils/firebase';
+import { fuego } from '../utils/firebase';
 
 const useStyles = makeStyles({
   root: {
@@ -17,7 +17,7 @@ const useStyles = makeStyles({
   },
 });
 const MenuVar = () => {
-  const currentUser = useContext(AuthContext).currentUser;
+  const currentUser = fuego.auth().currentUser;
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
   const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
     setAnchorEl(event.currentTarget);

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@material-ui/core": "^4.11.3",
         "@material-ui/icons": "^4.11.2",
         "@material-ui/lab": "^4.0.0-alpha.57",
+        "@nandorojo/swr-firestore": "^0.16.0",
         "@tailwindcss/line-clamp": "^0.2.0",
         "autoprefixer": "^10.2.1",
         "firebase": "^7.24.0",
@@ -667,6 +668,19 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0",
         "react-dom": "^16.8.0 || ^17.0.0"
+      }
+    },
+    "node_modules/@nandorojo/swr-firestore": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@nandorojo/swr-firestore/-/swr-firestore-0.16.0.tgz",
+      "integrity": "sha512-nl5ZN9Gpkf+lQaMwrlw4H2I6vThZaV0jg5Y9Gqt6WhQjC3aaWDwAWbvZ1WkSc65lxpK+NaK3uWCN/7gHh8SbhQ==",
+      "dependencies": {
+        "lodash.get": "^4.4.2",
+        "lodash.set": "^4.3.2",
+        "swr": "^0.2.0"
+      },
+      "peerDependencies": {
+        "react": "*"
       }
     },
     "node_modules/@next/env": {
@@ -2189,6 +2203,11 @@
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
     },
+    "node_modules/fast-deep-equal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+      "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
+    },
     "node_modules/fast-text-encoding": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/fast-text-encoding/-/fast-text-encoding-1.0.3.tgz",
@@ -3174,6 +3193,16 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
       "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY="
+    },
+    "node_modules/lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
+    },
+    "node_modules/lodash.set": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/lodash.set/-/lodash.set-4.3.2.tgz",
+      "integrity": "sha1-2HV7HagH3eJIFrDWqEvqGnYjCyM="
     },
     "node_modules/lodash.sortby": {
       "version": "4.7.0",
@@ -5105,6 +5134,17 @@
         "node": ">=8"
       }
     },
+    "node_modules/swr": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/swr/-/swr-0.2.3.tgz",
+      "integrity": "sha512-JhuuD5ojqgjAQpZAhoPBd8Di0Mr1+ykByVKuRJdtKaxkUX/y8kMACWKkLgLQc8pcDOKEAnbIreNjU7HfqI9nHQ==",
+      "dependencies": {
+        "fast-deep-equal": "2.0.1"
+      },
+      "peerDependencies": {
+        "react": "^16.11.0"
+      }
+    },
     "node_modules/symbol-observable": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
@@ -5980,6 +6020,16 @@
         "@babel/runtime": "^7.4.4",
         "prop-types": "^15.7.2",
         "react-is": "^16.8.0 || ^17.0.0"
+      }
+    },
+    "@nandorojo/swr-firestore": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@nandorojo/swr-firestore/-/swr-firestore-0.16.0.tgz",
+      "integrity": "sha512-nl5ZN9Gpkf+lQaMwrlw4H2I6vThZaV0jg5Y9Gqt6WhQjC3aaWDwAWbvZ1WkSc65lxpK+NaK3uWCN/7gHh8SbhQ==",
+      "requires": {
+        "lodash.get": "^4.4.2",
+        "lodash.set": "^4.3.2",
+        "swr": "^0.2.0"
       }
     },
     "@next/env": {
@@ -7242,6 +7292,11 @@
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
     },
+    "fast-deep-equal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+      "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
+    },
     "fast-text-encoding": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/fast-text-encoding/-/fast-text-encoding-1.0.3.tgz",
@@ -8023,6 +8078,16 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
       "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY="
+    },
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
+    },
+    "lodash.set": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/lodash.set/-/lodash.set-4.3.2.tgz",
+      "integrity": "sha1-2HV7HagH3eJIFrDWqEvqGnYjCyM="
     },
     "lodash.sortby": {
       "version": "4.7.0",
@@ -9527,6 +9592,14 @@
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
       "requires": {
         "has-flag": "^4.0.0"
+      }
+    },
+    "swr": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/swr/-/swr-0.2.3.tgz",
+      "integrity": "sha512-JhuuD5ojqgjAQpZAhoPBd8Di0Mr1+ykByVKuRJdtKaxkUX/y8kMACWKkLgLQc8pcDOKEAnbIreNjU7HfqI9nHQ==",
+      "requires": {
+        "fast-deep-equal": "2.0.1"
       }
     },
     "symbol-observable": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@material-ui/core": "^4.11.3",
     "@material-ui/icons": "^4.11.2",
     "@material-ui/lab": "^4.0.0-alpha.57",
+    "@nandorojo/swr-firestore": "^0.16.0",
     "@tailwindcss/line-clamp": "^0.2.0",
     "autoprefixer": "^10.2.1",
     "firebase": "^7.24.0",

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,8 +1,9 @@
 import Head from 'next/head';
 import { createContext, useEffect, useState } from 'react';
-import { auth } from '../utils/firebase';
+import { auth, fuego } from '../utils/firebase';
 import 'tailwindcss/tailwind.css';
 import { User } from 'firebase';
+import { FuegoProvider } from '@nandorojo/swr-firestore';
 
 type AuthContextProps = {
   currentUser: User | null | undefined;
@@ -28,9 +29,9 @@ const MyApp = ({ Component, pageProps }: any) => {
       <Head>
         <link rel='shortcut icon' href='/favicon.ico' />
       </Head>
-      <AuthContext.Provider value={{ currentUser }}>
+      <FuegoProvider fuego={fuego}>
         <Component {...pageProps} />
-      </AuthContext.Provider>
+      </FuegoProvider>
     </>
   );
 };

--- a/pages/library.tsx
+++ b/pages/library.tsx
@@ -1,51 +1,28 @@
 import Layout from '../components/Layout';
 import LibraryCard from '../components/LibraryCard';
 import React from 'react';
+import { useCollection } from '@nandorojo/swr-firestore';
+import { fuego } from '../utils/firebase';
 
 export default function Library() {
-  const books = [
-    {
-      id: 0,
-      imgUrl:
-        'https://images-na.ssl-images-amazon.com/images/I/51srrwLATIL._SX390_BO1,204,203,200_.jpg',
-      title: '1冊ですべて身につくHTML & CSSとWebデザイン入門講座',
-      texts: [],
-    },
-    {
-      id: 1,
-      imgUrl: 'https://m.media-amazon.com/images/I/41i89jqMyPL.jpg',
-      title: 'なるほどデザイン',
-      texts: [
-        'Lorem ipsum dolor, sit amet consectetur adipisicing elit.Quam quidem laborum, quae impedit laboriosam dolore nemorecusandae, iusto blanditiis soluta omnis hic magni sit? Expedita!',
-        'Quo officia perspiciatis accusamus aliquam repellendus optio vel ipsum cupiditate tenetur hic voluptate fugit laudantium quod aliquid itaque quasi enim, dicta ducimus.',
-      ],
-    },
-    {
-      id: 2,
-      imgUrl:
-        'https://images-na.ssl-images-amazon.com/images/I/51ekcrVqOSL._SX350_BO1,204,203,200_.jpg',
-      title: 'キタミ式イラストIT塾 基本情報技術者 令和03年',
-      texts: [
-        'Lorem ipsum dolor, sit amet consectetur adipisicing elit.Quam quidem laborum, quae impedit laboriosam dolore nemorecusandae, iusto blanditiis soluta omnis hic magni sit? Expedita!',
-        'Quo officia perspiciatis accusamus aliquam repellendus optio vel ipsum cupiditate tenetur hic voluptate fugit laudantium quod aliquid itaque quasi enim, dicta ducimus.',
-        'laudantium quod aliquid itaque quasi enim, dicta ducimus.',
-      ],
-    },
-  ];
+  const currentUser = fuego.auth().currentUser;
+  const { data } = useCollection(`users/${currentUser?.uid}/books`, {
+    listen: true,
+  });
 
+  if (!data) return <Layout>loading</Layout>;
   return (
     <Layout>
       <div className='py-16 px-2'>
         <h2 className='pt-8 text-center font-bold'>📚 マイライブラリ 📚</h2>
         <div className='grid gap-4 bg-grey-light p-4 w-full'>
-          {books &&
-            books.map((book) => (
+          {data &&
+            data.map((book: any) => (
               <div key={book.id}>
                 <LibraryCard
                   bid={book.id}
                   imgUrl={book.imgUrl}
-                  title={book.title}
-                  texts={book.texts}
+                  title={book.name}
                 ></LibraryCard>
               </div>
             ))}

--- a/utils/book.ts
+++ b/utils/book.ts
@@ -9,8 +9,8 @@ export const addBook = (
   imgUrl: string
 ) => {
   firebase.firestore().doc(`users/${uid}/books/${bid}`).set({
-    name: { name },
-    imgUrl: { imgUrl },
+    name: name,
+    imgUrl: imgUrl,
     memories: [],
   });
 };

--- a/utils/firebase.ts
+++ b/utils/firebase.ts
@@ -1,6 +1,7 @@
 import 'firebase/auth';
 import 'firebase/firestore';
 import firebase from 'firebase/app';
+import { Fuego } from '@nandorojo/swr-firestore';
 
 const config = {
   apiKey: process.env.NEXT_PUBLIC_FIREBASE_KEY,
@@ -12,12 +13,10 @@ const config = {
   appId: process.env.NEXT_PUBLIC_FIREBASE_APPID,
 };
 
-// initializeを複数回走らせない
-if (firebase.apps.length === 0) {
-  firebase.initializeApp(config);
-}
-
+const fuego = new Fuego(config);
 const auth = firebase.auth();
+
+//Googleログインの設定値
 const uiConfig = {
   signInFlow: 'popup',
   signInOptions: [firebase.auth.GoogleAuthProvider.PROVIDER_ID],
@@ -26,4 +25,4 @@ const uiConfig = {
   },
   signInSuccessUrl: '/library',
 };
-export { auth, uiConfig };
+export { auth, uiConfig, fuego };

--- a/utils/memory.tsx
+++ b/utils/memory.tsx
@@ -3,14 +3,17 @@ import 'firebase/firestore';
 import firebase from 'firebase/app';
 import { useEffect, useState } from 'react';
 
+import { fuego } from '../utils/firebase';
+
 //Firebase上のメモリー監視用フック
 //変更があったタイミングで対象本のメモリーを返却
 export const useMemory = (id: string) => {
   const [memories, setMemory] = useState<any>();
+  const currentUser = fuego.auth().currentUser;
   useEffect(() => {
     const unsub = firebase
       .firestore()
-      .doc(`books/${id}`)
+      .doc(`users/${currentUser?.uid}/books/${id}`)
       .onSnapshot((snap) => {
         setMemory(snap.data()?.memories || []);
       });
@@ -22,7 +25,8 @@ export const useMemory = (id: string) => {
 //メモリー作成（追加、編集、削除、全てこの関数で行う）
 //配列丸ごと更新させる
 export const addMemory = (id: string, newMemories?: string[]) => {
-  return firebase.firestore().doc(`books/${id}`).update({
+  const currentUser = fuego.auth().currentUser;
+  firebase.firestore().doc(`users/${currentUser?.uid}/books/${id}`).update({
     memories: newMemories,
   });
 };


### PR DESCRIPTION
fix #68 

## 実装内容
- swr-firestoreの導入(https://github.com/nandorojo/swr-firestore)
- ログイン情報の取得方法の変更
  - 今までは_appのAuthContextでログイン情報を配布して各コンポーネントでuseContextで取得していましたが、
 上記のswr-firestoreを導入することにより、fuego.auth().currentUserで取得するように変更
- 各ユーザー単位での本を登録、メモリーの登録更新削除
  - 今まではユーザーごとで切り分けておらず、どのユーザーでも同じライブラリ及びメモリーが見えてしまっていた

ご確認お願いします！