### PR TITLE
feature(Library):textareaのサイズ自動調整

### DIFF
--- a/components/LibraryMemory.tsx
+++ b/components/LibraryMemory.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react';
 import MemoryMoreVart from './MemoryMoreVart';
 import IconButton from '@material-ui/core/IconButton';
 import CheckOutlinedIcon from '@material-ui/icons/CheckOutlined';
+import TextareaAutosize from '@material-ui/core/TextareaAutosize';
 
 type Props = {
   bid: string;
@@ -29,7 +30,7 @@ const LibraryMemory = ({ bid, input, onChange, onClick, memories }: Props) => {
             className='group px-4 items-center text-sm cursor-pointer'
           >
             <div className='flex p-1 bg-white border-gray-100 rounded-md'>
-              <p className='pl-3 rounded-md flex-1 bg-white whitespace-pre-line break-all'>
+              <p className='pl-2 rounded-md flex-1 bg-white whitespace-pre-line break-all'>
                 {memory}
               </p>
 
@@ -44,13 +45,14 @@ const LibraryMemory = ({ bid, input, onChange, onClick, memories }: Props) => {
       <li className='mx-4 items-center text-sm flex relative rounded-md bg-white'>
         {!maxMemoryFlg ? (
           <>
-            <textarea
-              wrap='hard'
-              value={input}
-              onChange={onChange}
+            <TextareaAutosize
+              rowsMin={2}
               placeholder='入力する'
-              className='ml-3 mr-7 p-1 rounded-md flex-1 resize-none focus:outline-none'
-            ></textarea>
+              value={input}
+              wrap='hard'
+              onChange={onChange}
+              className='ml-2 mr-6 p-1 rounded-md flex-1 resize-none focus:outline-none'
+            ></TextareaAutosize>
 
             <div className='ml-2 absolute bottom-0 right-0 '>
               <IconButton

--- a/components/MemoryMoreVart.tsx
+++ b/components/MemoryMoreVart.tsx
@@ -67,7 +67,7 @@ const MemoryMoreVert = ({ bid, memoryIndex, memories }: Props) => {
   };
   const classes = useStyles();
   return (
-    <div className='ml-2 flex flex-col'>
+    <div className='flex flex-col'>
       <IconButton
         aria-label='more'
         aria-controls='simple-menu'


### PR DESCRIPTION
fix #70 
## 実装内容
- メモリーの入力欄(textarea)の縦サイズ自動調整実装（MaterialUIのTextareaAutosizeを利用）
- 若干のスタイル調整

## イメージ
![LibraryMemory-textarea](https://user-images.githubusercontent.com/66728424/112287385-a89e5600-8ccf-11eb-924e-cc022126db03.gif)

ご確認お願い致します！