### PR TITLE
feature(setting):退会処理

### DIFF
--- a/components/DeleteUserDialog.tsx
+++ b/components/DeleteUserDialog.tsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import Dialog from '@material-ui/core/Dialog';
+import DialogActions from '@material-ui/core/DialogActions';
+import DialogContent from '@material-ui/core/DialogContent';
+import DialogContentText from '@material-ui/core/DialogContentText';
+import DialogTitle from '@material-ui/core/DialogTitle';
+import { fuego } from '../utils/firebase';
+import { deleteDocument, useCollection } from '@nandorojo/swr-firestore';
+import Router from 'next/router';
+
+type Props = {
+  open: boolean;
+  closeHandle: VoidFunction;
+};
+
+export default function DeleteUserDialog({ open, closeHandle }: Props) {
+  const currentUser = fuego.auth().currentUser;
+  const { data } = useCollection(`users/${currentUser?.uid}/books`);
+
+  // 退会処理
+  const onClickDeleteUser = (uid: string) => {
+    data?.map((userBook) => {
+      deleteDocument(`users/${uid}/books/${userBook.id}`);
+    });
+    deleteDocument(`users/${uid}`);
+    closeHandle();
+    Router.push('/');
+    fuego.auth().signOut();
+    fuego.auth().currentUser?.delete();
+  };
+  return (
+    <div>
+      <Dialog
+        open={open}
+        onClose={closeHandle}
+        aria-labelledby='alert-dialog-title'
+        aria-describedby='alert-dialog-description'
+      >
+        <DialogTitle id='alert-dialog-title'>
+          退会します。宜しいですか？
+        </DialogTitle>
+        <DialogContent>
+          <DialogContentText id='alert-dialog-description'>
+            退会すると作成されたライブラリは全て削除され、戻すことはできません。
+          </DialogContentText>
+        </DialogContent>
+        <DialogActions>
+          <button
+            onClick={closeHandle}
+            className='bg-gray-200 p-2 mr-1 rounded-md focus:outline-none '
+          >
+            キャンセル
+          </button>
+          <button
+            onClick={() => {
+              currentUser && onClickDeleteUser(currentUser.uid);
+            }}
+            className='bg-red-500 text-white p-2 mr-1 rounded-md '
+          >
+            退会する
+          </button>
+        </DialogActions>
+      </Dialog>
+    </div>
+  );
+}

--- a/components/DeleteUserDialog.tsx
+++ b/components/DeleteUserDialog.tsx
@@ -5,34 +5,28 @@ import DialogContent from '@material-ui/core/DialogContent';
 import DialogContentText from '@material-ui/core/DialogContentText';
 import DialogTitle from '@material-ui/core/DialogTitle';
 import { fuego } from '../utils/firebase';
-import { deleteDocument, useCollection } from '@nandorojo/swr-firestore';
 import Router from 'next/router';
 
 type Props = {
   open: boolean;
-  closeHandle: VoidFunction;
+  handelClick: VoidFunction;
 };
 
-export default function DeleteUserDialog({ open, closeHandle }: Props) {
+export default function DeleteUserDialog({ open, handelClick }: Props) {
   const currentUser = fuego.auth().currentUser;
-  const { data } = useCollection(`users/${currentUser?.uid}/books`);
 
   // 退会処理
-  const onClickDeleteUser = (uid: string) => {
-    data?.map((userBook) => {
-      deleteDocument(`users/${uid}/books/${userBook.id}`);
-    });
-    deleteDocument(`users/${uid}`);
-    closeHandle();
-    Router.push('/');
-    fuego.auth().signOut();
-    fuego.auth().currentUser?.delete();
+  const onClickDeleteUser = async () => {
+    handelClick();
+    await Router.push('/');
+    await fuego.auth().currentUser?.delete();
+    await fuego.auth().signOut();
   };
   return (
     <div>
       <Dialog
         open={open}
-        onClose={closeHandle}
+        onClose={handelClick}
         aria-labelledby='alert-dialog-title'
         aria-describedby='alert-dialog-description'
       >
@@ -46,14 +40,14 @@ export default function DeleteUserDialog({ open, closeHandle }: Props) {
         </DialogContent>
         <DialogActions>
           <button
-            onClick={closeHandle}
+            onClick={handelClick}
             className='bg-gray-200 p-2 mr-1 rounded-md focus:outline-none '
           >
             キャンセル
           </button>
           <button
             onClick={() => {
-              currentUser && onClickDeleteUser(currentUser.uid);
+              currentUser && onClickDeleteUser();
             }}
             className='bg-red-500 text-white p-2 mr-1 rounded-md '
           >

--- a/components/LoginDialog.tsx
+++ b/components/LoginDialog.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Dialog from '@material-ui/core/Dialog';
 import StyledFirebaseAuth from 'react-firebaseui/StyledFirebaseAuth';
-import { uiConfig, auth } from '../utils/firebase';
+import { uiConfig, fuego } from '../utils/firebase';
 
 export interface LoginDialogProps {
   open: boolean;
@@ -15,7 +15,7 @@ const LoginDialog = (props: LoginDialogProps) => {
     <Dialog onClose={close} aria-labelledby='simple-dialog-title' open={open}>
       <div className='text-center p-4'>
         <p className='text-lg font-semibold'>読書管理をはじめる</p>
-        <StyledFirebaseAuth uiConfig={uiConfig} firebaseAuth={auth} />
+        <StyledFirebaseAuth uiConfig={uiConfig} firebaseAuth={fuego.auth()} />
         <p className='text-sm font-medium p-2'>
           ※Googleアカウントでのみログインできます
         </p>

--- a/components/MenuVar.tsx
+++ b/components/MenuVar.tsx
@@ -8,7 +8,6 @@ import Typography from '@material-ui/core/Typography';
 import { makeStyles } from '@material-ui/core/styles';
 import { useState } from 'react';
 import Router from 'next/router';
-import { auth } from '../utils/firebase';
 import { fuego } from '../utils/firebase';
 
 const useStyles = makeStyles({
@@ -34,7 +33,7 @@ const MenuVar = () => {
   };
   const onClickLogout = () => {
     Router.push('/');
-    auth.signOut();
+    fuego.auth().signOut();
   };
 
   const classes = useStyles();

--- a/components/SettingComponent.tsx
+++ b/components/SettingComponent.tsx
@@ -32,7 +32,7 @@ const SettingComponent = ({ title, contents }: Props) => {
       {onClickDialogClose && (
         <DeleteUserDialog
           open={deleteUserDialogopen}
-          closeHandle={onClickDialogClose}
+          handelClick={onClickDialogClose}
         ></DeleteUserDialog>
       )}
     </div>

--- a/components/SettingComponent.tsx
+++ b/components/SettingComponent.tsx
@@ -1,20 +1,42 @@
-import React from "react";
-
+import React, { useState } from 'react';
+import DeleteUserDialog from '../components/DeleteUserDialog';
 type Props = {
   title: string;
   contents: string;
 };
 
-const SettingComponent = ({ title, contents }: Props) => (
-  <div className="py-8 border-b-2">
-    <h2 className="text-lg font-semibold">{title}</h2>
-    <p className="mt-6">{contents}</p>
-    {title === "退会" && (
-      <button className="mt-4 px-4 py-2 border rounded-md shadow text-sm text-black focus:* focus:outline-none">
-        退会する
-      </button>
-    )}
-  </div>
-);
+const SettingComponent = ({ title, contents }: Props) => {
+  // ーーー編集ダイアログ用ーーー //
+  const [deleteUserDialogopen, setDeleteUserDialogOpen] = useState(false);
+  // 退会ダイアログ閉じる
+  const onClickDialogClose = () => {
+    setDeleteUserDialogOpen(false);
+  };
+  // 退会ダイアログ開く
+  const onClickEditDialogOpen = () => {
+    setDeleteUserDialogOpen(true);
+  };
+
+  return (
+    <div className='py-8 border-b-2'>
+      <h2 className='text-lg font-semibold'>{title}</h2>
+      <p className='mt-6'>{contents}</p>
+      {title === '退会' && (
+        <button
+          className='mt-4 px-4 py-2 border rounded-md shadow text-sm text-black focus:* focus:outline-none'
+          onClick={onClickEditDialogOpen}
+        >
+          退会する
+        </button>
+      )}
+      {onClickDialogClose && (
+        <DeleteUserDialog
+          open={deleteUserDialogopen}
+          closeHandle={onClickDialogClose}
+        ></DeleteUserDialog>
+      )}
+    </div>
+  );
+};
 
 export default SettingComponent;

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,6 +1,6 @@
 import Head from 'next/head';
 import { createContext, useEffect, useState } from 'react';
-import { auth, fuego } from '../utils/firebase';
+import { fuego } from '../utils/firebase';
 import 'tailwindcss/tailwind.css';
 import { User } from 'firebase';
 import { FuegoProvider } from '@nandorojo/swr-firestore';
@@ -19,7 +19,7 @@ const MyApp = ({ Component, pageProps }: any) => {
   );
 
   useEffect(() => {
-    auth.onAuthStateChanged((user) => {
+    fuego.auth().onAuthStateChanged((user) => {
       setCurrentUser(user);
     });
   });

--- a/pages/setting.tsx
+++ b/pages/setting.tsx
@@ -1,28 +1,30 @@
-import Layout from "../components/Layout";
-import SettingComponent from "../components/SettingComponent";
+import Layout from '../components/Layout';
+import SettingComponent from '../components/SettingComponent';
 
 export default function Terms() {
   const settingContents = [
     {
-      title: "プロフィールの変更",
+      title: 'プロフィールの変更',
       contents:
-        "このサイトではプロフィールの変更はできません。Googleのアカウント情報がそのまま反映されます。(ログイン時に反映されます。)",
+        'このサイトではプロフィールの変更はできません。Googleのアカウント情報がそのまま反映されます。(ログイン時に反映されます。)',
     },
     {
-      title: "退会",
+      title: '退会',
       contents:
-        "退会すると作成されたライブラリは全て削除され、戻すことはできません。",
+        '退会すると作成されたライブラリは全て削除され、戻すことはできません。',
     },
   ];
   return (
     <Layout>
-      <div className="pt-24 container-sm mx-auto px-4">
-        <h1 className="text-2xl pb-4 font-bold border-b-2">ユーザー設定</h1>
-        {settingContents.map((settingContent) => (
-          <SettingComponent
-            title={settingContent.title}
-            contents={settingContent.contents}
-          />
+      <div className='pt-24 container mx-auto px-4'>
+        <h1 className='text-2xl pb-4 font-bold border-b-2'>ユーザー設定</h1>
+        {settingContents.map((settingContent, idx) => (
+          <div key={idx}>
+            <SettingComponent
+              title={settingContent.title}
+              contents={settingContent.contents}
+            />
+          </div>
         ))}
       </div>
     </Layout>

--- a/utils/firebase.ts
+++ b/utils/firebase.ts
@@ -14,7 +14,6 @@ const config = {
 };
 
 const fuego = new Fuego(config);
-const auth = firebase.auth();
 
 //Googleログインの設定値
 const uiConfig = {
@@ -25,4 +24,4 @@ const uiConfig = {
   },
   signInSuccessUrl: '/library',
 };
-export { auth, uiConfig, fuego };
+export { uiConfig, fuego };


### PR DESCRIPTION
fix #30 

## 実装内容
- 退会処理
  - ユーザー設定画面の「退会する」ボタン押下→ダイアログ上の「退会する」ボタンを押して退会処理実行
  - ユーザーが登録している本（ドキュメント）の削除
  - ユーザーID（ドキュメント）の削除
  - auth削除
    ※ドキュメントの削除はswr-firestoreのdeleteDocumentを使用
- firebase.authをfuego.auth()に変更

## イメージ
![UserDelete](https://user-images.githubusercontent.com/66728424/112713610-6ec09000-8f19-11eb-989a-152e2800db3e.gif)

ご確認お願い致します！
