### PR TITLE
feature(search):検索処理(GoogleBooksAPI)

### DIFF
--- a/components/BookCard.tsx
+++ b/components/BookCard.tsx
@@ -30,7 +30,7 @@ const BookCard = ({ bid, imgUrl, title }: Props) => {
   };
 
   return (
-    <div className='w-48 p-2 text-center bg-white rounded shadow hover:shadow-lg'>
+    <div className='w-44 md:w-48 mx-auto p-2 text-center bg-blue-50 rounded-md shadow hover:shadow-lg'>
       <figure className='h-36 grid justify-center align-center'>
         <img
           src={imgUrl}

--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -1,22 +1,37 @@
-import React, { ReactNode, useState } from 'react';
+import React, { ReactNode, useState, ChangeEvent } from 'react';
 import Link from 'next/link';
 import Head from 'next/head';
 import LoginDialogButton from '../components/LoginDialogButton';
 import MenuVar from '../components/MenuVar';
-import { fuego } from '../utils/firebase';
+import { useRouter } from 'next/router';
+import { fuego } from '@nandorojo/swr-firestore';
 
 type Props = {
   children?: ReactNode;
   title?: string;
 };
 
-const Layout = ({ children, title = 'ブックメモリー' }: Props) => {
+export const Layout = ({ children, title = 'ブックメモリー' }: Props) => {
+  const router = useRouter();
   const currentUser = fuego.auth().currentUser;
   const [searchBarVisible, setSearchBarVisible] = useState(false);
-
+  const [searchInput, setSearchInput] = useState('');
+  //メモリー入力中関数
+  const onChangeSearchInput: any = (event: ChangeEvent<HTMLInputElement>) => {
+    setSearchInput(event.target.value);
+  };
   const onClickSearchBarVisible = () => {
     setSearchBarVisible(!searchBarVisible);
   };
+
+  const onClickSearchBook = (input: string) => {
+    if (input === '') return;
+    router.push({
+      pathname: '/search',
+      query: { booktitle: input },
+    });
+  };
+
   return (
     <div>
       <Head>
@@ -29,11 +44,16 @@ const Layout = ({ children, title = 'ブックメモリー' }: Props) => {
         <div className='ml-4 items-center hidden w-1/2 sm:flex'>
           <input
             type='text'
+            value={searchInput}
+            onChange={onChangeSearchInput}
             className='md:w-11/12 whitespace-nowrap px-2 py-2 border border-white rounded-l-md shadow-sm text-sm font-medium outline-none'
             placeholder='本のタイトルを入力'
           />
           <a
             href='#'
+            onClick={() => {
+              onClickSearchBook(searchInput);
+            }}
             className='inline-flex px-2 py-2 border border-white rounded-r-md shadow-sm text-sm font-medium text-white hover:bg-blue-500'
           >
             <img src='/images/search.svg' alt='' className='w-5 rounded-md' />
@@ -104,6 +124,13 @@ const Layout = ({ children, title = 'ブックメモリー' }: Props) => {
         </div>
         <p className='text-center m-4'>©️E-LOVE</p>
       </footer>
+
+      {/* {searchButtonFlg && (
+        <SearchBookDialog
+          open={searchButtonFlg}
+          close={closeSearchBookDialog}
+        />
+      )} */}
     </div>
   );
 };

--- a/interfaces/Book.ts
+++ b/interfaces/Book.ts
@@ -1,0 +1,5 @@
+export type Book = {
+  bid: string;
+  title: string;
+  imgUrl: string;
+};

--- a/pages/search.tsx
+++ b/pages/search.tsx
@@ -1,18 +1,37 @@
 import Layout from '../components/Layout';
 import BookCard from '../components/BookCard';
-import { books } from '../utils/search-books';
+import { useRouter } from 'next/router';
+import { searchBooks } from '../utils/search-books';
+import { useEffect, useState } from 'react';
+import { Book } from '../interfaces/Book';
 
 export default function Search() {
+  const router = useRouter();
+  //検索ヘッダの本のタイトルを取得
+  const booktitle: any = router.query.booktitle; //検索結果の保管ステート
+  const [bookList, setBookList] = useState<Book[]>([]);
+  //本検索処理　ヘッダが検索される都度処理発生
+  useEffect(() => {
+    booktitle &&
+      searchBooks(booktitle).then((books: Book[] | undefined) => {
+        books && setBookList(books);
+      });
+  }, [booktitle]);
   return (
     <Layout>
-      <div className='container mx-auto pt-20 text-center'>
-        　<p>検索結果</p>
-        <div className='grid grid-cols-2 gap-2 py-8 md:grid-cols-4 md:gap-4'>
-          {books.map((book: any, idx) => (
-            <div key={idx}>
-              <BookCard bid={book.id} imgUrl={book.imgUrl} title={book.title} />
-            </div>
-          ))}
+      <div className='pt-20 text-center bg-blue-100'>
+        　<p className='font-bold text-2xl'>検索結果</p>
+        <div className='container mx-auto grid grid-cols-2 gap-2 py-8 md:grid-cols-4 md:gap-4'>
+          {bookList &&
+            bookList.map((book: Book, idx) => (
+              <div key={idx}>
+                <BookCard
+                  bid={book.bid}
+                  imgUrl={book.imgUrl}
+                  title={book.title}
+                />
+              </div>
+            ))}
         </div>
       </div>
     </Layout>

--- a/utils/search-books.ts
+++ b/utils/search-books.ts
@@ -1,32 +1,20 @@
-export const books = [
-  {
-    id: 0,
-    imgUrl:
-      'https://images-na.ssl-images-amazon.com/images/I/51srrwLATIL._SX390_BO1,204,203,200_.jpg',
-    title: '1冊ですべて身につくHTML & CSSとWebデザイン入門講座',
-  },
-  {
-    id: 1,
-    imgUrl: 'https://m.media-amazon.com/images/I/41i89jqMyPL.jpg',
-    title: 'なるほどデザイン',
-  },
-  {
-    id: 2,
-    imgUrl:
-      'https://images-na.ssl-images-amazon.com/images/I/51ekcrVqOSL._SX350_BO1,204,203,200_.jpg',
-    title: 'キタミ式イラストIT塾 基本情報技術者 令和03年',
-  },
+import { Book } from '../interfaces/Book';
 
-  {
-    id: 3,
-    imgUrl:
-      'https://images-na.ssl-images-amazon.com/images/I/51AvRbVdAsL._SX394_BO1,204,203,200_.jpg',
-    title:
-      '改訂新版JavaScript本格入門 ~モダンスタイルによる基礎から現場での応用までaaaaaaaaaaaaaaaaaaaaaaaaaa',
-  },
-  {
-    id: 4,
-    imgUrl: 'https://m.media-amazon.com/images/I/51E4g6djCbL.jpg',
-    title: '働き方の哲学 360度の視点で仕事を考える',
-  },
-];
+export const searchBooks = async (bookTitle: string) => {
+  if (!bookTitle) return;
+  const res = await fetch(
+    `https://www.googleapis.com/books/v1/volumes?q=${bookTitle}`
+  );
+  if (!res) return;
+  const bookJson = await res.json();
+  const bookData: Book[] = await bookJson.items.map((data: any) => {
+    const item = data.volumeInfo;
+    const book: Book = {
+      bid: data.id,
+      title: item.title,
+      imgUrl: item.imageLinks ? item.imageLinks.smallThumbnail : '',
+    };
+    return book;
+  });
+  return bookData;
+};


### PR DESCRIPTION
fix #24 
## 実装内容
- GoogleBooksAPIによる検索処理
  - ヘッダーに値を入力し検索アイコン押下→ヘッダー値をRouterのクエリに渡し、検索画面(/search)に遷移
  - 検索画面のレンダリング時に↑で渡されたクエリ値があれば、検索処理開始（GoogleBooksAPI）
- 軽微なデザイン調整

## イメージ
![Search-Book](https://user-images.githubusercontent.com/66728424/113068402-319a1d80-91f9-11eb-802f-0986a4e1617e.gif)

ご確認お願い致します！