### PR TITLE
feature(library)：さらに表示実装

### DIFF
--- a/pages/library.tsx
+++ b/pages/library.tsx
@@ -1,31 +1,104 @@
 import Layout from '../components/Layout';
 import LibraryCard from '../components/LibraryCard';
-import React from 'react';
+import React, { useState } from 'react';
 import { useCollection } from '@nandorojo/swr-firestore';
 import { fuego } from '../utils/firebase';
+import Snackbar from '@material-ui/core/Snackbar';
+import MuiAlert, { AlertProps } from '@material-ui/lab/Alert';
+
+const limit = 10;
+
+// Snacbar表示用↓
+function Alert(props: AlertProps) {
+  return <MuiAlert elevation={6} variant="filled" {...props} />;
+}
 
 export default function Library() {
-  const currentUser = fuego.auth().currentUser;
-  const { data } = useCollection(`users/${currentUser?.uid}/books`, {
-    listen: true,
-  });
+  // Snackbar表示用（メモリー上限オーバーアラート）
+  const [isSnackbarNoMoreBook, setIsSnackbarNoMoreBook] = useState(false);
+  const closeSnackbarNoMoreBook = () => {
+    setIsSnackbarNoMoreBook(false);
+  };
+  const openSnackbarNoMoreBook = () => {
+    setIsSnackbarNoMoreBook(true);
+  };
 
-  if (!data) return <Layout>loading</Layout>;
+  const currentUser = fuego.auth().currentUser;
+  const { data, mutate } = useCollection(
+    `users/${currentUser?.uid}/books`,
+    {
+      limit,
+      ignoreFirestoreDocumentSnapshotField: false,
+      listen: true,
+    },
+    {
+      revalidateOnFocus: false,
+      refreshWhenHidden: false,
+      refreshWhenOffline: false,
+      refreshInterval: 0,
+    }
+  );
+
+  const paginate = async () => {
+    if (!data?.length) return;
+    const ref = fuego.db.collection(`users/${currentUser?.uid}/books`);
+    const startAfterDocument = data[data.length - 1].__snapshot;
+    const moreDocs = await ref
+      .startAfter(startAfterDocument)
+      .limit(limit)
+      .get()
+      .then((d) => {
+        const docs: any = [];
+        d.docs.forEach((doc) =>
+          docs.push({ ...doc.data(), id: doc.id, __snapshot: doc })
+        );
+        return docs;
+      });
+    moreDocs.length || openSnackbarNoMoreBook();
+    mutate((state) => [...state![Symbol.iterator](), ...moreDocs], false);
+  };
+  if (data?.length === 0)
+    return (
+      <Layout>
+        <div className="py-20 text-center text-gray-500">
+          <p>ライブラリはありません</p>
+          <p>本を登録してください</p>
+        </div>
+      </Layout>
+    );
   return (
     <Layout>
-      <div className="container mx-auto py-16 px-2">
-        <h2 className="pt-8 text-center font-bold">📚 マイライブラリ 📚</h2>
-        <div className="grid gap-4 bg-grey-light p-2 w-full">
-          {data &&
-            data.map((book: any) => (
-              <div key={book.id}>
-                <LibraryCard
-                  bid={book.id}
-                  imgUrl={book.imgUrl}
-                  title={book.name}
-                ></LibraryCard>
-              </div>
-            ))}
+      <div className="bg-blue-50">
+        <div className="container mx-auto py-16 px-2">
+          <p className="py-4 text-center text-5xl md:pt-8 md:text-7xl">📚</p>
+          <h1 className="pb-4 text-center text-lg font-bold md:text-2xl">
+            マイライブラリ
+          </h1>
+          <div className="grid gap-4 bg-grey-light p-2 w-full">
+            {data &&
+              data.map((book: any) => (
+                <div key={book.id}>
+                  <LibraryCard
+                    bid={book.id}
+                    imgUrl={book.imgUrl}
+                    title={book.name}
+                  ></LibraryCard>
+                </div>
+              ))}
+            <button
+              onClick={paginate}
+              className="mt-8 bg-gray-200 mx-auto py-4 px-8 rounded-full flex justify-center focus:outline-none"
+            >
+              さらに表示
+            </button>
+          </div>
+          <Snackbar
+            open={isSnackbarNoMoreBook}
+            onClose={closeSnackbarNoMoreBook}
+            autoHideDuration={3000}
+          >
+            <Alert severity="error">これ以上はありません</Alert>
+          </Snackbar>
         </div>
       </div>
     </Layout>


### PR DESCRIPTION
fix #76 
## 実装内容
- ライブラリ画面に「さらに表示」ボタン実装
  - 初期画面表示で１０件表示
  - 「さらに表示」ボタン押下でさらに１０件表示
  - 全て取得し終えた後に「さらに表示」ボタン押下でスナックバー「これ以上はありません」表示

## イメージ
![library_showmore](https://user-images.githubusercontent.com/66728424/115108442-6f45c700-9fab-11eb-8998-54838c55cd1c.gif)

ご確認お願い致します！