### PR TITLE
テスト後fix(deleteuser):ユーザー削除のファンクション化

### DIFF
--- a/components/DeleteUserDialog.tsx
+++ b/components/DeleteUserDialog.tsx
@@ -4,30 +4,27 @@ import DialogActions from '@material-ui/core/DialogActions';
 import DialogContent from '@material-ui/core/DialogContent';
 import DialogContentText from '@material-ui/core/DialogContentText';
 import DialogTitle from '@material-ui/core/DialogTitle';
-import { fuego } from '../utils/firebase';
-import Router from 'next/router';
+import { fuego, callable } from '../utils/firebase';
+import { useRouter } from 'next/router';
 
 type Props = {
   open: boolean;
   handelClick: VoidFunction;
 };
-
 export default function DeleteUserDialog({ open, handelClick }: Props) {
   const currentUser = fuego.auth().currentUser;
-
+  const router = useRouter();
   // 退会処理
   const onClickDeleteUser = async () => {
     handelClick();
-    await fuego
-      .auth()
-      .currentUser?.delete()
-      .catch(() => {
-        alert(
-          `退会するには再認証が必要です。お手数ですが、再度ログインしてもう一度退会処理を実行して下さい。`
-        );
+    callable({})
+      .then(() => {
+        fuego.auth().signOut();
+        router.push('/');
+      })
+      .catch((error) => {
+        console.error(error);
       });
-    await Router.push('/');
-    await fuego.auth().signOut();
   };
   return (
     <div>

--- a/utils/firebase.ts
+++ b/utils/firebase.ts
@@ -1,5 +1,6 @@
 import 'firebase/auth';
 import 'firebase/firestore';
+import 'firebase/functions';
 import firebase from 'firebase/app';
 import { Fuego } from '@nandorojo/swr-firestore';
 
@@ -24,4 +25,10 @@ const uiConfig = {
   },
   signInSuccessUrl: '/library',
 };
-export { uiConfig, fuego };
+
+//退会処理の呼び出し
+const app = firebase.app();
+const functions = app.functions('asia-northeast1');
+const callable = functions.httpsCallable('deleteUser');
+
+export { uiConfig, fuego, callable };


### PR DESCRIPTION
fix #93 
## 実装内容
ユーザー削除に設置し（functionのコードは[別リポジトリ](https://github.com/flock-team/book-memory-firebase/pull/1)）をhttpsCallableにて呼び出すようにしました。
ご確認お願いします！
