### PR TITLE
Fix/92(search)：検索画面の修正

### DIFF
--- a/components/BookCard.tsx
+++ b/components/BookCard.tsx
@@ -1,20 +1,21 @@
 import React, { useState } from 'react';
-import BookCardButton from '../components/BookCardButton';
+import { BookCardButton } from '../components/BookCardButton';
 import { addBook } from '../utils/book';
-import { fuego } from '../utils/firebase';
+
 import { SnackbarComponent } from './SnackbarComponent';
 
 type Props = {
   bid: string;
   imgUrl: string;
   title: string;
+  uid?: string;
+  isLibrary?: boolean;
 };
 
-const BookCard = ({ bid, imgUrl, title }: Props) => {
-  const currentUser = fuego.auth().currentUser;
+export const BookCard = ({ bid, imgUrl, title, uid, isLibrary }: Props) => {
   // 「ライブラリ登録」Snackbar表示ステイト
   const [openSnackbar, setOpenSnackbar] = useState(false);
-
+  console.log(isLibrary);
   // ライブラリ登録
   const addLibrary = () => {
     addBook(bid, title, imgUrl);
@@ -32,11 +33,14 @@ const BookCard = ({ bid, imgUrl, title }: Props) => {
       </figure>
       <p className="p-2 h-16 font-bold text-sm mb-2 line-clamp-3">{title}</p>
       <div className="flex flex-col">
-        {currentUser && (
-          <BookCardButton onClick={() => addLibrary()}>
-            ライブラリ登録
-          </BookCardButton>
-        )}
+        {uid &&
+          (isLibrary ? (
+            <BookCardButton onClick={() => {}}>登録済み</BookCardButton>
+          ) : (
+            <BookCardButton onClick={() => addLibrary()}>
+              ライブラリ登録
+            </BookCardButton>
+          ))}
       </div>
       <SnackbarComponent
         open={openSnackbar}
@@ -48,5 +52,3 @@ const BookCard = ({ bid, imgUrl, title }: Props) => {
     </div>
   );
 };
-
-export default BookCard;

--- a/components/BookCard.tsx
+++ b/components/BookCard.tsx
@@ -30,7 +30,7 @@ const BookCard = ({ bid, imgUrl, title }: Props) => {
   };
 
   return (
-    <div className="w-44 md:w-48 mx-auto p-2 text-center bg-blue-50 rounded-md shadow hover:shadow-lg">
+    <div className="w-40 md:w-48 mx-auto p-2 text-center bg-blue-50 rounded-md shadow hover:shadow-lg">
       <figure className="h-36 grid justify-center align-center">
         <img
           src={imgUrl}

--- a/components/BookCard.tsx
+++ b/components/BookCard.tsx
@@ -1,36 +1,28 @@
 import React, { useState } from 'react';
 import BookCardButton from '../components/BookCardButton';
-import Snackbar from '@material-ui/core/Snackbar';
-import MuiAlert, { AlertProps } from '@material-ui/lab/Alert';
 import { addBook } from '../utils/book';
 import { fuego } from '../utils/firebase';
+import { SnackbarComponent } from './SnackbarComponent';
 
 type Props = {
   bid: string;
   imgUrl: string;
   title: string;
 };
-// Snackbar表示用
-function Alert(props: AlertProps) {
-  return <MuiAlert elevation={6} variant="filled" {...props} />;
-}
 
 const BookCard = ({ bid, imgUrl, title }: Props) => {
   const currentUser = fuego.auth().currentUser;
   // 「ライブラリ登録」Snackbar表示ステイト
   const [openSnackbar, setOpenSnackbar] = useState(false);
-  const closeSnackbar = () => {
-    setOpenSnackbar(false);
-  };
 
   // ライブラリ登録
-  const onClickAddLibrary = () => {
+  const addLibrary = () => {
     addBook(bid, title, imgUrl);
     setOpenSnackbar(true);
   };
 
   return (
-    <div className="w-40 md:w-48 mx-auto p-2 text-center bg-blue-50 rounded-md shadow hover:shadow-lg">
+    <div className="w-40 md:w-48 mx-auto p-2 text-center bg-blue-50 rounded-md">
       <figure className="h-36 grid justify-center align-center">
         <img
           src={imgUrl}
@@ -41,20 +33,18 @@ const BookCard = ({ bid, imgUrl, title }: Props) => {
       <p className="p-2 h-16 font-bold text-sm mb-2 line-clamp-3">{title}</p>
       <div className="flex flex-col">
         {currentUser && (
-          <BookCardButton onClick={() => onClickAddLibrary()}>
+          <BookCardButton onClick={() => addLibrary()}>
             ライブラリ登録
           </BookCardButton>
         )}
       </div>
-      <Snackbar
+      <SnackbarComponent
         open={openSnackbar}
-        autoHideDuration={3000}
-        onClose={closeSnackbar}
+        close={() => setOpenSnackbar(false)}
+        severity="info"
       >
-        <Alert onClose={closeSnackbar} severity="info">
-          ライブラリに登録しました
-        </Alert>
-      </Snackbar>
+        ライブラリに登録しました
+      </SnackbarComponent>
     </div>
   );
 };

--- a/components/BookCardButton.tsx
+++ b/components/BookCardButton.tsx
@@ -5,20 +5,30 @@ type Props = {
   onClick: VoidFunction;
 };
 
-const BookCardButton = ({ children, onClick }: Props) => (
+export const BookCardButton = ({ children, onClick }: Props) => (
   <div className="flex flex-col">
-    <button
-      className={
-        children === 'Amazon詳細'
-          ? 'bg-yellow-400'
-          : 'bg-blue-400' +
-            ' text-white font-bold p-2 text-xs shadow rounded focus:outline-none hover:shadow-md'
-      }
-      onClick={onClick}
-    >
-      {children}
-    </button>
+    {children === '登録済み' ? (
+      <button
+        className={
+          'bg-gray-400 text-white font-bold p-2 text-xs rounded focus:outline-none'
+        }
+        onClick={onClick}
+        disabled={true}
+      >
+        {children}
+      </button>
+    ) : (
+      <button
+        className={
+          children === 'Amazon詳細'
+            ? 'bg-yellow-400'
+            : 'bg-blue-400' +
+              ' text-white font-bold p-2 text-xs shadow rounded focus:outline-none hover:shadow-md'
+        }
+        onClick={onClick}
+      >
+        {children}
+      </button>
+    )}
   </div>
 );
-
-export default BookCardButton;

--- a/components/BookCardButton.tsx
+++ b/components/BookCardButton.tsx
@@ -2,7 +2,7 @@ import React, { ReactNode } from 'react';
 
 type Props = {
   children: ReactNode;
-  onClick: any;
+  onClick: VoidFunction;
 };
 
 const BookCardButton = ({ children, onClick }: Props) => (
@@ -10,8 +10,9 @@ const BookCardButton = ({ children, onClick }: Props) => (
     <button
       className={
         children === 'Amazon詳細'
-          ? 'bg-yellow-400 text-white font-bold p-2 text-xs shadow rounded focus:outline-none'
-          : 'bg-blue-400 text-white font-bold p-2 text-xs shadow rounded focus:outline-none'
+          ? 'bg-yellow-400'
+          : 'bg-blue-400' +
+            ' text-white font-bold p-2 text-xs shadow rounded focus:outline-none hover:shadow-md'
       }
       onClick={onClick}
     >

--- a/components/SnackbarComponent.tsx
+++ b/components/SnackbarComponent.tsx
@@ -1,0 +1,29 @@
+import React, { ReactNode } from 'react';
+import Snackbar from '@material-ui/core/Snackbar';
+import MuiAlert, { AlertProps, Color } from '@material-ui/lab/Alert';
+
+type Props = {
+  open: boolean;
+  close: VoidFunction;
+  children: ReactNode;
+  severity: Color;
+};
+// Snackbar表示用
+function Alert(props: AlertProps) {
+  return <MuiAlert elevation={6} variant="filled" {...props} />;
+}
+
+export const SnackbarComponent = ({
+  open,
+  close,
+  children,
+  severity,
+}: Props) => {
+  return (
+    <Snackbar open={open} autoHideDuration={2000} onClose={close}>
+      <Alert onClose={close} severity={severity}>
+        {children}
+      </Alert>
+    </Snackbar>
+  );
+};

--- a/pages/search.tsx
+++ b/pages/search.tsx
@@ -1,15 +1,27 @@
 import Layout from '../components/Layout';
-import BookCard from '../components/BookCard';
+import { BookCard } from '../components/BookCard';
 import { useRouter } from 'next/router';
 import { searchBooks } from '../utils/search-books';
 import { useEffect, useState } from 'react';
 import { Book } from '../interfaces/Book';
+import { fuego } from '../utils/firebase';
+import { useCollection } from '@nandorojo/swr-firestore';
 
 export default function Search() {
   const router = useRouter();
+  //ユーザー取得
+  const currentUser = fuego.auth().currentUser;
+
+  //ユーザーのライブラリのドキュメントid（bid）取得
+  const { data } = useCollection(`users/${currentUser?.uid}/books`, {
+    listen: true,
+  });
+  const libraryBookId = data?.map((bookData) => bookData.id);
+
   //検索ヘッダの本のタイトルを取得
   const booktitle: any = router.query.booktitle; //検索結果の保管ステート
   const [bookList, setBookList] = useState<Book[]>([]);
+
   //本検索処理　ヘッダが検索される都度処理発生
   useEffect(() => {
     booktitle &&
@@ -33,6 +45,8 @@ export default function Search() {
                   bid={book.bid}
                   imgUrl={book.imgUrl}
                   title={book.title}
+                  uid={currentUser?.uid}
+                  isLibrary={libraryBookId?.includes(book.bid)}
                 />
               </div>
             ))}

--- a/pages/search.tsx
+++ b/pages/search.tsx
@@ -22,7 +22,7 @@ export default function Search() {
       <div className="pt-16 text-center bg-blue-100">
         <p className="py-4 text-center text-5xl md:pt-8 md:text-7xl">🔎</p>
         <h1 className="text-center text-lg font-bold md:text-2xl">検索結果</h1>
-        <div className="container mx-auto grid grid-cols-2 gap-2 py-8 md:grid-cols-4 md:gap-4">
+        <div className="container mx-auto grid grid-cols-2 gap-1 py-8 md:grid-cols-4 md:gap-4">
           {bookList &&
             bookList.map((book: Book, idx) => (
               <div key={idx}>

--- a/pages/search.tsx
+++ b/pages/search.tsx
@@ -21,10 +21,13 @@ export default function Search() {
     <Layout>
       <div className="pt-16 text-center bg-blue-100">
         <p className="py-4 text-center text-5xl md:pt-8 md:text-7xl">🔎</p>
-        <h1 className="text-center text-lg font-bold md:text-2xl">検索結果</h1>
-        <div className="container mx-auto grid grid-cols-2 gap-1 py-8 md:grid-cols-4 md:gap-4">
-          {bookList &&
-            bookList.map((book: Book, idx) => (
+        <h1 className="pb-1 text-center text-lg font-bold md:text-2xl tracking-widest">
+          検索結果
+        </h1>
+        <p>（上位10件を表示）</p>
+        {bookList?.length ? (
+          <div className="container mx-auto grid grid-cols-2 gap-1 py-8 md:grid-cols-4 md:gap-4">
+            {bookList.map((book: Book, idx) => (
               <div key={idx}>
                 <BookCard
                   bid={book.bid}
@@ -33,7 +36,10 @@ export default function Search() {
                 />
               </div>
             ))}
-        </div>
+          </div>
+        ) : (
+          <p className="text-center py-10">本は見つかりませんでした</p>
+        )}
       </div>
     </Layout>
   );


### PR DESCRIPTION
fix #92 
## 実装内容
- [x] カードの影消す　登録ボタンに影
- [x] 検索結果（上位10件）
- [x] 本が無い場合、該当する本がありませんでした
- [x] ライブラリに登録したら登録済みにする
- [x] スナックバーのコンポーネント化 

## イメージ
![image](https://user-images.githubusercontent.com/66728424/116776172-fc0b7d00-aaa1-11eb-9071-2f5599a22ae4.png)

ご確認お願いします！